### PR TITLE
233 - Fix: Display the text for the quantile normalization skipped in download files summary

### DIFF
--- a/src/components/Download/FilesSummary.js
+++ b/src/components/Download/FilesSummary.js
@@ -132,6 +132,11 @@ export const FilesSummary = ({ dataset }) => {
               <Text weight="bold">
                 Transformation: {transformationOptions[dataset.scale_by]}
               </Text>
+              {!dataset.quantile_normalize && (
+                <Text weight="bold">
+                  Quantile Normalization Skipped for RNA-seq samples
+                </Text>
+              )}
               <Text weight="bold">
                 <Button
                   label="Change"


### PR DESCRIPTION
## Issue Number

Closing #233

## Purpose/Implementation Notes
Rendered the text in UI for the datasets with the quantile normalization skipped in the download files summary section.

Please see the latest UI [here](https://refinebio-web-git-nozomione-233-display-text-for-qn-3be506-ccdl.vercel.app/).

A dataset (e.g., [`6a702ffe-0eb3-468f-b648-f15807f47037`](https://refinebio-web-git-nozomione-233-display-text-for-qn-3be506-ccdl.vercel.app/dataset/6a702ffe-0eb3-468f-b648-f15807f47037)) with QN skipped.

## Types of changes
-Bugfix (non-breaking change which fixes an issue)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules
