### PR TITLE
376- Remove config.options from compendia URL routes

### DIFF
--- a/src/components/Compendia/RNASeqTab.js
+++ b/src/components/Compendia/RNASeqTab.js
@@ -1,11 +1,12 @@
 import { memo } from 'react'
 import { Anchor, Box, Heading, Paragraph, Text } from 'grommet'
 import { useResponsive } from 'hooks/useResponsive'
+import getReadable from 'helpers/getReadable'
 import { Button } from 'components/shared/Button'
 import { Column } from 'components/shared/Column'
 import { FixedContainer } from 'components/shared/FixedContainer'
 import { Row } from 'components/shared/Row'
-import { links, options } from 'config'
+import { links } from 'config'
 import { DownloadBlock } from './DownloadBlock'
 
 const Card = ({ heading, pad, children }) => {
@@ -75,7 +76,9 @@ export const RNASeqTab = ({ type = 'rnaSeq' }) => {
               Note: This compendia is not normalized or aggregated.
             </Paragraph>
             <Button
-              aria-label={`Go to the refinebio docs - ${options.compendia.tabs[1].label}`}
+              aria-label={`Go to the refinebio docs - ${getReadable(
+                'rna-seq'
+              )}`}
               href={links.refinebio_docs_rna_seq_sample_compendia}
               label="Learn More"
               margin={{ top: 'small' }}

--- a/src/components/Compendia/Tabs.js
+++ b/src/components/Compendia/Tabs.js
@@ -1,29 +1,39 @@
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/router'
 import { Tab } from 'grommet'
-import { options } from 'config'
+import getReadable from 'helpers/getReadable'
 import { Tabs as SharedTabs } from 'components/shared/Tabs'
 import { NormalizedTab } from './NormalizedTab'
 import { RNASeqTab } from './RNASeqTab'
 
 export const Tabs = () => {
   const {
-    compendia: { tabs }
-  } = options
-  const { isReady, pathname, query, replace } = useRouter()
+    isReady,
+    pathname,
+    query: { type },
+    replace
+  } = useRouter()
   const [activeIndex, setActiveIndex] = useState(0)
   const handleActive = (nextIndex) => setActiveIndex(nextIndex)
+  const tabs = [
+    {
+      type: 'normalized',
+      Component: NormalizedTab
+    },
+    {
+      type: 'rna-seq',
+      Component: RNASeqTab
+    }
+  ]
 
   useEffect(() => {
     if (!isReady) return
 
-    setActiveIndex(query.type === 'rna-seq' ? 1 : 0)
-  }, [isReady, query])
+    setActiveIndex(type === 'rna-seq' ? 1 : 0)
+  }, [isReady, type])
 
   const clickHandle = (tabType) => {
-    const tabName = tabType === 'rnaSeq' ? 'rna-seq' : tabType
-
-    replace({ pathname, query: { type: tabType } }, `/compendia/${tabName}`, {
+    replace({ pathname, query: { type: tabType } }, `/compendia/${tabType}`, {
       shallow: true
     })
   }
@@ -32,15 +42,11 @@ export const Tabs = () => {
     <SharedTabs activeIndex={activeIndex} text onActive={handleActive}>
       {tabs.map((tab) => (
         <Tab
-          key={tab.type}
-          title={tab.label}
+          title={getReadable(tab.type)}
           onClick={() => clickHandle(tab.type)}
         >
-          {tab.type === tabs[0].type ? (
-            <NormalizedTab type={tab.type} />
-          ) : (
-            <RNASeqTab type={tab.type} />
-          )}
+          {/* TEMP: camelCase to prevent sub-comonents from breaking (will update in a later stacked issue) */}
+          <tab.Component type={tab.type === 'rna-seq' ? 'rnaSeq' : tab.type} />
         </Tab>
       ))}
     </SharedTabs>

--- a/src/components/Compendia/Tabs.js
+++ b/src/components/Compendia/Tabs.js
@@ -42,6 +42,7 @@ export const Tabs = () => {
     <SharedTabs activeIndex={activeIndex} text onActive={handleActive}>
       {tabs.map((tab) => (
         <Tab
+          key={tab.type}
           title={getReadable(tab.type)}
           onClick={() => clickHandle(tab.type)}
         >

--- a/src/components/Header/GlobalNav.js
+++ b/src/components/Header/GlobalNav.js
@@ -3,7 +3,7 @@ import { useRouter } from 'next/router'
 import { Box, Nav, Text } from 'grommet'
 import { useDatasetManager } from 'hooks/useDatasetManager'
 import { useResponsive } from 'hooks/useResponsive'
-import { links, options } from 'config'
+import { links } from 'config'
 import isMatchPath from 'helpers/isMatchPath'
 import { BadgedButton } from 'components/shared/BadgedButton'
 import { LayerResponsive } from 'components/shared/LayerResponsive'
@@ -20,9 +20,6 @@ export const GlobalNav = ({ light = false, toggle = false, setToggle }) => {
   const { viewport, setResponsive } = useResponsive()
   const { dataset, datasetId, getDataset, getTotalSamples } =
     useDatasetManager()
-  const {
-    compendia: { tabs }
-  } = options
   const [totalSamples, setTotalSamples] = useState()
 
   useEffect(() => {
@@ -102,17 +99,22 @@ export const GlobalNav = ({ light = false, toggle = false, setToggle }) => {
                     </Text>
                   </Box>
                   <Box pad={{ horizontal: 'small' }}>
-                    {tabs.map(({ label, path }) => (
-                      <NavLink
-                        key={label}
-                        active={isMatchPath(asPath, path)}
-                        label={label}
-                        light={light}
-                        href={path}
-                        viewport={viewport}
-                        onClick={handleClick}
-                      />
-                    ))}
+                    <NavLink
+                      active={isMatchPath(asPath, '/compendia/normalized')}
+                      label="Normalized Compendia"
+                      light={light}
+                      href="/compendia/normalized"
+                      viewport={viewport}
+                      onClick={handleClick}
+                    />
+                    <NavLink
+                      active={isMatchPath(asPath, '/compendia/rna-seq')}
+                      label="RNA-seq Sample Compendia"
+                      light={light}
+                      href="/compendia/rna-seq"
+                      viewport={viewport}
+                      onClick={handleClick}
+                    />
                   </Box>
                 </>
               ) : (

--- a/src/components/Header/NavDropDown.js
+++ b/src/components/Header/NavDropDown.js
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { useRouter } from 'next/router'
 import { Box, Text } from 'grommet'
 import styled, { css } from 'styled-components'
-import { options } from 'config'
 import isMatchPath from 'helpers/isMatchPath'
 import { Anchor } from 'components/shared/Anchor'
 import { Button as SharedButton } from 'components/shared/Button'
@@ -65,10 +64,16 @@ const ListItem = ({ active, href, label, ...props }) => (
 export const NavDropDown = ({ active, light }) => {
   const router = useRouter()
   const { asPath } = router
-  const {
-    compendia: { tabs }
-  } = options
-  const menuItems = tabs.map(({ label, path }) => ({ label, path }))
+  const tabItems = [
+    {
+      label: 'Normalized Compendia',
+      path: '/compendia/normalized'
+    },
+    {
+      label: 'RNA-seq Sample Compendia',
+      path: '/compendia/rna-seq'
+    }
+  ]
   const [isOpen, setIsOpen] = useState(false)
 
   const handleClick = () => {
@@ -123,7 +128,7 @@ export const NavDropDown = ({ active, light }) => {
             pad="none"
             role="menu"
           >
-            {menuItems.map(({ label, path }) => (
+            {tabItems.map(({ label, path }) => (
               <ListItem
                 key={label}
                 active={isMatchPath(asPath, path)}

--- a/src/config/readables.js
+++ b/src/config/readables.js
@@ -1,4 +1,7 @@
-export const readableAttributes = {}
+export const readableAttributes = {
+  normalized: 'Normalized Compendia',
+  'rna-seq': 'RNA-seq Sample Compendia'
+}
 
 const readableAnalyticsBooleans = {
   checked: ['Add - ', 'Remove - '],

--- a/src/config/readables.js
+++ b/src/config/readables.js
@@ -1,7 +1,4 @@
-export const readableAttributes = {
-  normalized: 'Normalized Compendia',
-  'rna-seq': 'RNA-seq Sample Compendia'
-}
+export const readableAttributes = {}
 
 const readableAnalyticsBooleans = {
   checked: ['Add - ', 'Remove - '],
@@ -25,5 +22,7 @@ export const readableValues = {
   '-num_downloadable_samples': 'Most No. of samples',
   num_downloadable_samples: 'Least No. of samples',
   '-source_first_published': 'Newest Experiment',
-  source_first_published: 'Oldest Experiment'
+  source_first_published: 'Oldest Experiment',
+  normalized: 'Normalized Compendia',
+  'rna-seq': 'RNA-seq Sample Compendia'
 }


### PR DESCRIPTION
## Issue Number

Epic: #366

Closes #376 (Stacked issue 1)

## Purpose/Implementation Notes

Changes include:
- Removed the dependency of `options.compendia.tabs` from the route-related components
- Utilize the` getReadable` helper to get each tab title
- Delete `options.compendia.tabs` from config


## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
