### PR TITLE
375 - Use useEffect to trigger fetch in useSamplesTable

### DIFF
--- a/src/components/shared/SamplesTable/SamplesTable.js
+++ b/src/components/shared/SamplesTable/SamplesTable.js
@@ -1,4 +1,3 @@
-/* eslint-disable no-nested-ternary */
 import { memo, useEffect, useMemo, useState } from 'react'
 import { Box, Spinner, Text } from 'grommet'
 import { useResponsive } from 'hooks/useResponsive'
@@ -54,11 +53,9 @@ export const SamplesTable = ({
   } = useSamplesTableManager(queryToAdd)
   const { viewport, setResponsive } = useResponsive()
   const [tableExpanded, setTableExpanded] = useState(false)
-  const tableHeight = tableExpanded ? '75vh' : '800px' // required for the table height on expanded view
-  // default settings for react-table
-  const minColumns = 5 // the number of columns to display
+
+  // for react-table
   const defaultColumn = useMemo(
-    // the column size
     () => ({ minWidth: 60, width: 160, maxWidth: 250 }),
     []
   )
@@ -139,8 +136,13 @@ export const SamplesTable = ({
 
     return temp
   }, [isImmutable, viewport])
+
+  // for the expand table button
   const totalColumns =
-    tableData && sampleMetadataFields ? columns.length - 2 : 0 // excludes add/remove and hidden cells
+    tableData && sampleMetadataFields ? columns.length - 2 : 0 // excludes the add/remove and hidden cells
+  const isTableExpandable =
+    !modalView && viewport === 'large' && totalColumns > 5 // sets the button visivility
+  const tableHeight = tableExpanded ? '75vh' : '800px' // toggles the table height on expanded view
 
   useEffect(() => {
     getSamplesTableData()
@@ -207,14 +209,12 @@ export const SamplesTable = ({
                 placeholder="Filter samples"
               />
             </Box>
-            {!modalView &&
-              viewport === 'large' &&
-              totalColumns > minColumns && (
-                <ExpandTableButton
-                  tableExpanded={tableExpanded}
-                  setTableExpanded={setTableExpanded}
-                />
-              )}
+            {!isTableExpandable && (
+              <ExpandTableButton
+                tableExpanded={tableExpanded}
+                setTableExpanded={setTableExpanded}
+              />
+            )}
           </Box>
         </Row>
         <BoxBlock>

--- a/src/components/shared/SamplesTable/SamplesTable.js
+++ b/src/components/shared/SamplesTable/SamplesTable.js
@@ -39,7 +39,6 @@ export const SamplesTable = ({
     samplesTable: { pageSizes }
   } = options
   const {
-    config: { defaultColumn, minColumns },
     hasError,
     hasSamples,
     loading,
@@ -56,6 +55,13 @@ export const SamplesTable = ({
   const { viewport, setResponsive } = useResponsive()
   const [tableExpanded, setTableExpanded] = useState(false)
   const tableHeight = tableExpanded ? '75vh' : '800px' // required for the table height on expanded view
+  // default settings for react-table
+  const minColumns = 5 // the number of columns to display
+  const defaultColumn = useMemo(
+    // the column size
+    () => ({ minWidth: 60, width: 160, maxWidth: 250 }),
+    []
+  )
   const data = useMemo(() => tableData.results, [tableData])
   const columns = useMemo(() => {
     const temp = [

--- a/src/contexts/SamplesTableManagerContext.js
+++ b/src/contexts/SamplesTableManagerContext.js
@@ -9,13 +9,6 @@ export const SamplesTableManagerContextProvider = ({ children }) => {
   } = options
   const [config, setConfig] = useState({
     commonQueries,
-    // the default column size
-    defaultColumn: useMemo(
-      () => ({ minWidth: 60, width: 160, maxWidth: 250 }),
-      []
-    ),
-    // the default number of columns to display
-    minColumns: 5,
     page,
     pageSize: pageSizes[0]
   })

--- a/src/hooks/useSamplesTableManager.js
+++ b/src/hooks/useSamplesTableManager.js
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 import { api } from 'api'
 import { SamplesTableManagerContext } from 'contexts/SamplesTableManagerContext'
 
@@ -11,6 +11,11 @@ export const useSamplesTableManager = (queryToAdd = {}) => {
   const [tableData, setTableData] = useState([])
   const hasSamples = tableData?.results?.length > 0
   const totalPages = (tableData && tableData.count) || 0
+
+  // fetches the table data on samplesTable changes
+  useEffect(() => {
+    getSamplesTableData()
+  }, [samplesTable])
 
   /* Common */
   const resetPage = () => {
@@ -97,14 +102,10 @@ export const useSamplesTableManager = (queryToAdd = {}) => {
   }
 
   const updateSamplesTableQuery = (reset = false) => {
-    if (reset) {
-      resetPage()
-    }
+    if (reset) resetPage()
 
     samplesTable.reset = reset
-
     setSamplesTable({ ...samplesTable })
-    getSamplesTableData()
   }
 
   return {


### PR DESCRIPTION
## Issue Number

Closes #375

## Purpose/Implementation Notes

Changes include:
- Use `useEffect` to fetch the table data on the `samplesTable` query change
- Co-located the default settings for `react-table` within the `SamplesTable` component

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
