### PR TITLE
380 - Refactor usePollDatasetStatus to accept a new parameter for polling check

### DIFF
--- a/src/components/shared/SearchCard/SearchCardAction/SearchCardAction.js
+++ b/src/components/shared/SearchCard/SearchCardAction/SearchCardAction.js
@@ -14,9 +14,9 @@ export const SearchCardAction = ({ experiment, technology }) => {
     num_downloadable_samples: downloadableSamples,
     organism_names: organismNames
   } = experiment
-  const { isProcessingDataset, pollDatasetAccession } = usePollDatasetStatus()
-  pollDatasetAccession(accessionCode) // checks this accession code for polling
+  const { datasetAccessions } = usePollDatasetStatus(accessionCode)
   const { setResponsive } = useResponsive()
+  const isProcessingOneOff = accessionCode in datasetAccessions
   const hasMultipleOrganisms = organismNames.length > 1
   const rnaSeq = 'RNA-SEQ'
   const hasRnaSeq =
@@ -29,7 +29,7 @@ export const SearchCardAction = ({ experiment, technology }) => {
 
   return (
     <>
-      {isProcessingDataset && (
+      {isProcessingOneOff && (
         <Box margin={{ bottom: 'small' }}>
           <ProcessingDatasetPill accessionCode={accessionCode} />
         </Box>
@@ -42,7 +42,7 @@ export const SearchCardAction = ({ experiment, technology }) => {
         primary
       />
 
-      {!isProcessingDataset && (
+      {!isProcessingOneOff && (
         <Box margin={{ top: 'small' }} width={setResponsive('100%', 'auto')}>
           <DownloadNowButton
             accessionCode={accessionCode}

--- a/src/components/shared/SearchCard/SearchCardAction/SearchCardAction.js
+++ b/src/components/shared/SearchCard/SearchCardAction/SearchCardAction.js
@@ -14,9 +14,8 @@ export const SearchCardAction = ({ experiment, technology }) => {
     num_downloadable_samples: downloadableSamples,
     organism_names: organismNames
   } = experiment
-  const { datasetAccessions } = usePollDatasetStatus(accessionCode)
+  const { isProcessingDataset } = usePollDatasetStatus(accessionCode)
   const { setResponsive } = useResponsive()
-  const isProcessingOneOff = accessionCode in datasetAccessions
   const hasMultipleOrganisms = organismNames.length > 1
   const rnaSeq = 'RNA-SEQ'
   const hasRnaSeq =
@@ -29,7 +28,7 @@ export const SearchCardAction = ({ experiment, technology }) => {
 
   return (
     <>
-      {isProcessingOneOff && (
+      {isProcessingDataset && (
         <Box margin={{ bottom: 'small' }}>
           <ProcessingDatasetPill accessionCode={accessionCode} />
         </Box>
@@ -42,7 +41,7 @@ export const SearchCardAction = ({ experiment, technology }) => {
         primary
       />
 
-      {!isProcessingOneOff && (
+      {!isProcessingDataset && (
         <Box margin={{ top: 'small' }} width={setResponsive('100%', 'auto')}>
           <DownloadNowButton
             accessionCode={accessionCode}

--- a/src/hooks/usePollDatasetStatus.js
+++ b/src/hooks/usePollDatasetStatus.js
@@ -1,8 +1,8 @@
 import { useEffect, useState, useRef } from 'react'
 import { useDatasetManager } from 'hooks/useDatasetManager'
 
-// takes either an accession code (one-off) or a dataset ID
-export const usePollDatasetStatus = (accessionCodeOrDatasetId) => {
+// takes either an accession code or a dataset ID to poll / check status
+export const usePollDatasetStatus = (accessionOrId) => {
   const { datasetAccessions, processingDatasets, getDataset } =
     useDatasetManager()
   const [polledDatasetId, setPolledDatasetId] = useState(null)
@@ -12,8 +12,13 @@ export const usePollDatasetStatus = (accessionCodeOrDatasetId) => {
 
   // starts polling the dataset status
   useEffect(() => {
-    pollDatasetStatus()
-  }, [])
+    if (accessionOrId in datasetAccessions) {
+      pollDatasetId(datasetAccessions[accessionOrId])
+    }
+    if (processingDatasets.includes(accessionOrId)) {
+      pollDatasetId(accessionOrId)
+    }
+  }, [accessionOrId, processingDatasets])
 
   // polls the latest state of the processing dataset per minute
   // (the processing usually takes a few minutes)
@@ -33,23 +38,8 @@ export const usePollDatasetStatus = (accessionCodeOrDatasetId) => {
     }
   }, [isProcessingDataset])
 
-  // sets the dataset ID via the given accessionCodeOrDatasetId
-  const pollDatasetStatus = () => {
-    pollDatasetAccession(accessionCodeOrDatasetId)
-    pollDatasetId(accessionCodeOrDatasetId)
-  }
-
-  // if one-off, sets the matched accession code's dataset ID to polledDatasetId
-  const pollDatasetAccession = (accessionCode) => {
-    if (accessionCode in datasetAccessions) {
-      pollDatasetId(datasetAccessions[accessionCode])
-    }
-  }
-
   // sets the mached dataset ID to polledDatasetId
   const pollDatasetId = (datasetId) => {
-    if (datasetId === polledDatasetId) return
-
     const isProcessing = processingDatasets.includes(datasetId)
     if (isProcessing) {
       setPolledDatasetId(datasetId)
@@ -70,10 +60,7 @@ export const usePollDatasetStatus = (accessionCodeOrDatasetId) => {
   }
 
   return {
-    datasetAccessions,
     isProcessingDataset,
-    polledDatasetState,
-    pollDatasetAccession,
-    pollDatasetId
+    polledDatasetState
   }
 }

--- a/src/pages/dataset/[dataset_id].js
+++ b/src/pages/dataset/[dataset_id].js
@@ -31,8 +31,8 @@ export const Dataset = ({ query }) => {
   const { dataset_id: idFromQuery, start } = query
   const { dataset, datasetId, error, loading, getDataset, regeneratedDataset } =
     useDatasetManager()
-  const { isProcessingDataset, polledDatasetState, pollDatasetId } =
-    usePollDatasetStatus()
+  const { isProcessingDataset, polledDatasetState } =
+    usePollDatasetStatus(idFromQuery)
   const [selectedDataset, setSelectedDataset] = useState({}) // stores the dataset currently displayed on the page
   const isProcessed = selectedDataset?.is_processed && selectedDataset?.success // sets visibility of the download options in Dwonload Files Summary
   const isUnprocessedDataset = // sets visibility of the Download Dataset button
@@ -47,7 +47,6 @@ export const Dataset = ({ query }) => {
 
   useEffect(() => {
     getSelectedDataset(idFromQuery)
-    pollDatasetId(idFromQuery) // sets a processing datasets for polling
   }, [query])
 
   useEffect(() => {


### PR DESCRIPTION
## Issue Number

Closes #380

## Purpose/Implementation Notes
I've added the new parameter `accessionCodeOrDatasetId` to `usePollDatasetStatus`  and adjusted the codeabse.

Changes include:
- Added the new `accessionCodeOrDatasetId` parameter to `usePollDatasetStatus` 
- Added a new `useEffect` block to initiate the dataset polling in `usePollDatasetStatus`
- Remove method calls from `[dataset_id]` and `SearchCardAction` components and adjusted the codebase

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
