### PR TITLE
407 - Validate tokens with API call instead of regex in useToken

### DIFF
--- a/src/components/Dataset/DatasetReady.js
+++ b/src/components/Dataset/DatasetReady.js
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
 import { Box, Heading, Text } from 'grommet'
 import gtag from 'analytics/gtag'
 import { useDatasetManager } from 'hooks/useDatasetManager'
@@ -17,13 +17,22 @@ export const DatasetReady = ({ dataset }) => {
   const { downloadDataset } = useDatasetManager()
   const { setResponsive } = useResponsive()
   const { validateToken } = useToken()
-  const hasToken = validateToken()
-  const [termsOfUse, setTermsOfUse] = useState(hasToken)
+  const [acceptedTerms, setAcceptedTerms] = useState(false)
 
   const handleDownloadNow = async () => {
     await downloadDataset(dataset.id, dataset.download_url)
     gtag.trackDatasetDownload(dataset)
   }
+
+  const getTokenStatus = async () => {
+    const isActivated = await validateToken()
+    setAcceptedTerms(isActivated)
+  }
+
+  // sets acceptedTerms based on the token validity
+  useEffect(() => {
+    getTokenStatus()
+  }, [])
 
   return (
     <>
@@ -49,7 +58,7 @@ export const DatasetReady = ({ dataset }) => {
                 }}
                 fill
               >
-                {!hasToken && (
+                {!acceptedTerms && (
                   <Column align={setResponsive('center', 'start')}>
                     <CheckBox
                       label={
@@ -63,7 +72,7 @@ export const DatasetReady = ({ dataset }) => {
                           />
                         </Text>
                       }
-                      onClick={() => setTermsOfUse(!termsOfUse)}
+                      onClick={() => setAcceptedTerms(!acceptedTerms)}
                     />
                   </Column>
                 )}
@@ -71,14 +80,14 @@ export const DatasetReady = ({ dataset }) => {
                   align={setResponsive('center', 'start')}
                   margin={{
                     top: setResponsive('medium', 'small', 'none'),
-                    left: hasToken
+                    left: acceptedTerms
                       ? 'none'
                       : setResponsive('none', 'none', 'medium')
                   }}
                 >
                   <Button
                     label="Download Now"
-                    disabled={!termsOfUse}
+                    disabled={!acceptedTerms}
                     primary
                     responsive
                     onClick={handleDownloadNow}

--- a/src/hooks/useCompendia.js
+++ b/src/hooks/useCompendia.js
@@ -5,12 +5,7 @@ import { api } from 'api'
 
 export const useCompendia = () => {
   const { push } = useRouter()
-  const {
-    token: tokenState,
-    createToken,
-    resetToken,
-    validateToken
-  } = useToken()
+  const { token, resetToken, validateToken } = useToken()
   const [loading, setLoading] = useState(false)
   const [hasError, setHasError] = useState(false)
 
@@ -22,7 +17,7 @@ export const useCompendia = () => {
     }
 
     setLoading(true)
-    const response = await api.compendia.get(compendiaQuery, tokenState)
+    const response = await api.compendia.get(compendiaQuery, token)
     setHasError(!response.ok)
     setLoading(false)
 
@@ -35,10 +30,9 @@ export const useCompendia = () => {
       : 'normalized'
 
   const downloadCompendia = async (compendiaId) => {
-    const token = !validateToken()
-      ? await resetToken()
-      : tokenState || (await createToken())
-    const response = await api.compendia.download(compendiaId, token)
+    // validates the existing token or create a new one
+    const tokenToUse = (await validateToken()) ? token : await resetToken()
+    const response = await api.compendia.download(compendiaId, tokenToUse)
 
     return {
       organism: response.primary_organism_name,
@@ -46,7 +40,7 @@ export const useCompendia = () => {
     }
   }
 
-  const navigateToFileDownload = (organism, url) => {
+  const navigateToFileDownload = async (organism, url) => {
     push({
       pathname: '/compendia/download',
       query: {

--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -90,7 +90,7 @@ export const useDatasetManager = () => {
 
   const downloadDataset = async (id, downloadUrl) => {
     let href = ''
-    if (validateToken() && downloadUrl) {
+    if ((await validateToken()) && downloadUrl) {
       href = downloadUrl
     } else {
       // creates a new token and requests a download url with API-Key
@@ -149,8 +149,8 @@ export const useDatasetManager = () => {
     accessionCode = null
   ) => {
     const isCurrentDatasetId = id && id === datasetId
-    // validates the existing token or create a new token if none
-    const tokenId = validateToken() ? token : await resetToken()
+    // validates the existing token or create a new one
+    const tokenId = (await validateToken()) ? token : await resetToken()
     const { emailAddress, receiveUpdates } = options
     const params = {
       ...getDownloadOptions(options),

--- a/src/hooks/useToken.js
+++ b/src/hooks/useToken.js
@@ -30,13 +30,10 @@ export const useToken = () => {
     return id
   }
 
-  const validateToken = () => {
-    // regex for uuid
-    // (resource) https://ihateregex.io/expr/uuid/
-    const re =
-      /^[0-9a-f]{8}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{4}\b-[0-9a-f]{12}$/
+  const validateToken = async () => {
+    const response = await api.token.get(token)
 
-    return re.test(tokenState)
+    return response.is_activated
   }
 
   return {


### PR DESCRIPTION
## Issue Number

Closes #407

## Purpose/Implementation Notes

I've updated the `validateToken` method in the `useToken` hook to make an API call and adjusted the codebase accordingly. 

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
