### PR TITLE
Fix bugs introduced in #403 merge in dev 

### DIFF
--- a/src/components/Download/DatasetSummary/SpeciesRow.js
+++ b/src/components/Download/DatasetSummary/SpeciesRow.js
@@ -1,28 +1,32 @@
 import { TableCell, TableRow, Text } from 'grommet'
+import getArrayCounts from 'helpers/getArrayCounts'
 import formatNumbers from 'helpers/formatNumbers'
 import formatString from 'helpers/formatString'
 
-export const SpiecesRow = ({
-  samplesBySpecies = [],
-  experimentCountBySpecies = []
-}) => (
-  <>
-    {Object.keys(samplesBySpecies).map((organism) => (
-      <TableRow key={organism}>
-        <TableCell>{formatString(organism)}</TableCell>
-        <TableCell>
-          <Text color="brand">
-            {formatNumbers(samplesBySpecies[organism]?.length)}
-          </Text>
-        </TableCell>
-        <TableCell>
-          <Text color="brand">
-            {formatNumbers(experimentCountBySpecies[organism]) || 0}
-          </Text>
-        </TableCell>
-      </TableRow>
-    ))}
-  </>
-)
+export const SpiecesRow = ({ dataset }) => {
+  const { experiments, organism_samples: organismSamples } = dataset
+  const experimentCountByOrganism = getArrayCounts(
+    experiments.map((e) => e.organism_names).flat()
+  )
 
+  return (
+    <>
+      {Object.keys(organismSamples).map((organism) => (
+        <TableRow key={organism}>
+          <TableCell>{formatString(organism)}</TableCell>
+          <TableCell>
+            <Text color="brand">
+              {formatNumbers(organismSamples[organism]?.length)}
+            </Text>
+          </TableCell>
+          <TableCell>
+            <Text color="brand">
+              {formatNumbers(experimentCountByOrganism[organism]) || 0}
+            </Text>
+          </TableCell>
+        </TableRow>
+      ))}
+    </>
+  )
+}
 export default SpiecesRow

--- a/src/components/Download/DatasetSummary/TotalRow.js
+++ b/src/components/Download/DatasetSummary/TotalRow.js
@@ -1,8 +1,15 @@
 import { nanoid } from 'nanoid'
 import { TableCell, TableRow, Text } from 'grommet'
+import { useDatasetManager } from 'hooks/useDatasetManager'
 import formatNumbers from 'helpers/formatNumbers'
 
-export const TotalRow = ({ totals = [] }) => {
+export const TotalRow = ({ dataset }) => {
+  const { getTotalExperiments, getTotalSamples } = useDatasetManager()
+  const totals = [
+    getTotalSamples(dataset.data),
+    getTotalExperiments(dataset.data)
+  ]
+
   return (
     <TableRow>
       <TableCell>Total</TableCell>

--- a/src/components/Download/DatasetSummary/index.js
+++ b/src/components/Download/DatasetSummary/index.js
@@ -13,26 +13,28 @@ import { Row } from 'components/shared/Row'
 import { SpiecesRow } from './SpeciesRow'
 import { TotalRow } from './TotalRow'
 
-// returns the count of expriment by spcecies
-const getExperimentCountBySpecies = (data, experiments) => {
+// returns the experiment count per organism
+const getExperimentCountByOrganisms = (data, experiments) => {
   if (!data || !experiments) return {}
 
-  const species = {}
+  const experimentCounts = {}
 
   for (const accessionCode of Object.keys(data)) {
-    const experimentInfo = experiments[accessionCode]
+    const experiment = experiments.find(
+      (e) => e.accession_code === accessionCode
+    )
 
-    if (!experimentInfo) return {}
+    if (!experiment) return {}
 
-    const { organism_names: organismNames } = experimentInfo
+    const { organism_names: organismNames } = experiment
 
     for (const organism of organismNames) {
-      if (!species[organism]) species[organism] = 0
-      species[organism] += 1
+      if (!experimentCounts[organism]) experimentCounts[organism] = 0
+      experimentCounts[organism] += 1
     }
   }
 
-  return species
+  return experimentCounts
 }
 
 export const DatasetSummary = ({ dataset }) => {
@@ -40,7 +42,7 @@ export const DatasetSummary = ({ dataset }) => {
   const { setResponsive } = useResponsive()
   const totalSamples = getTotalSamples(dataset.data)
   const totalExperiments = getTotalExperiments(dataset.data)
-  const experimentCountBySpecies = getExperimentCountBySpecies(
+  const experimentCountBySpecies = getExperimentCountByOrganisms(
     dataset.data,
     dataset.experiments
   )

--- a/src/components/Download/DatasetSummary/index.js
+++ b/src/components/Download/DatasetSummary/index.js
@@ -14,25 +14,17 @@ import { SpiecesRow } from './SpeciesRow'
 import { TotalRow } from './TotalRow'
 
 // returns the experiment count per organism
-const getExperimentCountByOrganisms = (data, experiments) => {
-  if (!data || !experiments) return {}
-
+const getExperimentCountByOrganisms = ({ experiments }) => {
   const experimentCounts = {}
 
-  for (const accessionCode of Object.keys(data)) {
-    const experiment = experiments.find(
-      (e) => e.accession_code === accessionCode
-    )
-
-    if (!experiment) return {}
-
-    const { organism_names: organismNames } = experiment
-
-    for (const organism of organismNames) {
-      if (!experimentCounts[organism]) experimentCounts[organism] = 0
+  experiments.forEach(({ organism_names: organismNames }) => {
+    organismNames.forEach((organism) => {
+      if (!experimentCounts[organism]) {
+        experimentCounts[organism] = 0
+      }
       experimentCounts[organism] += 1
-    }
-  }
+    })
+  })
 
   return experimentCounts
 }
@@ -42,10 +34,7 @@ export const DatasetSummary = ({ dataset }) => {
   const { setResponsive } = useResponsive()
   const totalSamples = getTotalSamples(dataset.data)
   const totalExperiments = getTotalExperiments(dataset.data)
-  const experimentCountBySpecies = getExperimentCountByOrganisms(
-    dataset.data,
-    dataset.experiments
-  )
+  const experimentCountBySpecies = getExperimentCountByOrganisms(dataset)
 
   return (
     <Box margin={{ top: 'large' }}>

--- a/src/components/Download/DatasetSummary/index.js
+++ b/src/components/Download/DatasetSummary/index.js
@@ -7,34 +7,13 @@ import {
   TableHeader,
   TableRow
 } from 'grommet'
-import { useDatasetManager } from 'hooks/useDatasetManager'
 import { useResponsive } from 'hooks/useResponsive'
 import { Row } from 'components/shared/Row'
 import { SpiecesRow } from './SpeciesRow'
 import { TotalRow } from './TotalRow'
 
-// returns the experiment count per organism
-const getExperimentCountByOrganisms = ({ experiments }) => {
-  const experimentCounts = {}
-
-  experiments.forEach(({ organism_names: organismNames }) => {
-    organismNames.forEach((organism) => {
-      if (!experimentCounts[organism]) {
-        experimentCounts[organism] = 0
-      }
-      experimentCounts[organism] += 1
-    })
-  })
-
-  return experimentCounts
-}
-
 export const DatasetSummary = ({ dataset }) => {
-  const { getTotalExperiments, getTotalSamples } = useDatasetManager()
   const { setResponsive } = useResponsive()
-  const totalSamples = getTotalSamples(dataset.data)
-  const totalExperiments = getTotalExperiments(dataset.data)
-  const experimentCountBySpecies = getExperimentCountByOrganisms(dataset)
 
   return (
     <Box margin={{ top: 'large' }}>
@@ -60,11 +39,8 @@ export const DatasetSummary = ({ dataset }) => {
             </TableRow>
           </TableHeader>
           <TableBody style={{ fontSize: setResponsive('16px', '18px') }}>
-            <SpiecesRow
-              samplesBySpecies={dataset.organism_samples}
-              experimentCountBySpecies={experimentCountBySpecies}
-            />
-            <TotalRow totals={[totalSamples, totalExperiments]} />
+            <SpiecesRow dataset={dataset} />
+            <TotalRow dataset={dataset} />
           </TableBody>
         </Table>
       </Row>

--- a/src/components/Download/DownloadOptionsForm/index.js
+++ b/src/components/Download/DownloadOptionsForm/index.js
@@ -39,7 +39,7 @@ export const DownloadOptionsForm = ({
       dataset.id,
       isProcessed
     )
-  }, [dataset])
+  }, [])
 
   const handleSubmitForm = async (downloadOptions) => {
     let pathname = '/download'

--- a/src/helpers/getArrayCounts.js
+++ b/src/helpers/getArrayCounts.js
@@ -1,0 +1,9 @@
+// Returns an object with the count of element occurrences in the given array
+// e.g.,
+// Input: [ 'a', 'b', 'b' ]
+// Output: { a: 1, b: 2 }
+export default (arr) =>
+  arr.reduce((acc, cur) => {
+    acc[cur] = (acc[cur] || 0) + 1
+    return acc
+  }, {})

--- a/src/helpers/getPlatformNamesFromExperiment.js
+++ b/src/helpers/getPlatformNamesFromExperiment.js
@@ -6,7 +6,7 @@ export default ({
   pretty_platforms: prettyPlatforms = [],
   platform_names: platformNames = []
 }) => {
-  if (prettyPlatforms) return prettyPlatforms
+  if (prettyPlatforms.length) return prettyPlatforms
 
   if (samples.length) {
     return unionizeArrays(...samples.map((sample) => sample.pretty_platform))

--- a/src/pages/experiments/[accession_code]/[title]/index.js
+++ b/src/pages/experiments/[accession_code]/[title]/index.js
@@ -55,6 +55,8 @@ export const Experiment = ({ experiment }) => {
     }
   }, [fromViewSamples, hasSamples])
 
+  if (!hasSamples) return <Spinner />
+
   return (
     <>
       <PageTitle title={`${`${accessionCode} - ${experiment.title}`} -`} />
@@ -78,11 +80,7 @@ export const Experiment = ({ experiment }) => {
                 pad={setResponsive('medium', 'large')}
                 margin={{ bottom: 'basex6' }}
               >
-                {hasSamples ? (
-                  <ExperimentSamplesTable experiment={experiment} />
-                ) : (
-                  <Spinner />
-                )}
+                <ExperimentSamplesTable experiment={experiment} />
               </Box>
             </FixedContainer>
           </Box>

--- a/src/pages/search/index.js
+++ b/src/pages/search/index.js
@@ -20,6 +20,7 @@ import { Pagination } from 'components/shared/Pagination'
 import { SearchBox } from 'components/shared/SearchBox'
 import { SearchInfoBanner } from 'components/SearchResults/SearchInfoBanner'
 import { SearchCard } from 'components/shared/SearchCard'
+import { Spinner } from 'components/shared/Spinner'
 import {
   RequestSearchFormAlert,
   NoSearchResults,
@@ -56,6 +57,9 @@ export const Search = ({
   const [sortBy, setSortBy] = useState(query.sortby || sortby[0].value)
   const isResults = results?.length > 0
 
+  // TODO: Remove when refactring search in a future issue (prevent hydration error)
+  const [isPageReady, setIsPageReady] = useState(false)
+
   const handleClearSearchTerm = () => {
     setUserSearchTerm('')
   }
@@ -64,6 +68,9 @@ export const Search = ({
     e.preventDefault()
     updateSearchTerm(userSearchTerm)
   }
+  useEffect(() => {
+    setIsPageReady(true)
+  }, [])
 
   useEffect(() => {
     if (facets) {
@@ -79,11 +86,14 @@ export const Search = ({
         })
       }
     }
-  }, [])
+  }, [facets, query])
 
   useEffect(() => {
     gtag.trackSearchQuery(query)
   }, [query])
+
+  // TODO: Remove when refactring search in a future issue
+  if (!isPageReady) return <Spinner />
 
   return (
     <>


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

This PR resolves issues introduced in `dev` following the merge of #403 (commit 753aef5). Instead of reverting the merge, these bugs are fixed in this PR to preserve the other changes made in subsequent PRs.

- Removed `dataset` from the `useEffect` dependency array in the `DownloadOptionForm` (accidentally overwritten during the merge)
- Use the ‘find’ method to retrieve the `experiment` for each organisms in `getExperimentCountByOrganisms` in `DatasetSummary` (formerly `getExperimentCountBySpecies`,  renamaed to reflect latest `dev` updates)  
- Added `length` property to `if` statement for `prettyPlatforms`  in `helpers/getPlatformNamesExperiment`
- Replaced JSX ternary with an early return for `hasSamples` in the `Experiment` page component to prevent hydration errors 
- (temp) Added the `isPageReady` state in `Search` page component to avoid hydration errors with `TODO` comments for future refactoring

Please let me know if you have any questions. Thank you David!

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

N/A

## Screenshots

N/A
