### PR TITLE
392 - Rename context states for DatasetManagerContext

### DIFF
--- a/src/components/Dataset/MoveToDatasetButton.js
+++ b/src/components/Dataset/MoveToDatasetButton.js
@@ -9,11 +9,7 @@ import { MoveToDatasetModal } from './MoveToDatasetModal'
 
 export const MoveToDatasetButton = ({ dataset }) => {
   const { push } = useRouter()
-  const {
-    dataset: myDataset,
-    addSamples,
-    getTotalSamples
-  } = useDatasetManager()
+  const { myDataset, addSamples, getTotalSamples } = useDatasetManager()
   const { openModal, closeModal } = useModal()
   const id = `move-to-dataset-${dataset.id}`
   const radioOptions = [

--- a/src/components/Dataset/MoveToDatasetModal.js
+++ b/src/components/Dataset/MoveToDatasetModal.js
@@ -20,16 +20,11 @@ export const MoveToDatasetModal = ({
   value,
   setValue
 }) => {
-  const {
-    dataset: datasetState,
-    loading,
-    addSamples,
-    getTotalSamples,
-    replaceSamples
-  } = useDatasetManager()
+  const { myDataset, loading, addSamples, getTotalSamples, replaceSamples } =
+    useDatasetManager()
   const { setResponsive } = useResponsive()
   const { push } = useRouter()
-  const totalSamples = formatNumbers(getTotalSamples(datasetState.data))
+  const totalSamples = formatNumbers(getTotalSamples(myDataset.data))
   const newDatasetTotalSamples = formatNumbers(getTotalSamples(dataset.data))
 
   const handleMoveSamples = async (action = 'append') => {

--- a/src/components/Header/GlobalNav.js
+++ b/src/components/Header/GlobalNav.js
@@ -18,17 +18,17 @@ export const GlobalNav = ({ light = false, toggle = false, setToggle }) => {
   const router = useRouter()
   const { asPath, pathname } = router
   const { viewport, setResponsive } = useResponsive()
-  const { dataset, datasetId, getDataset, getTotalSamples } =
+  const { myDataset, myDatasetId, getDataset, getTotalSamples } =
     useDatasetManager()
   const [totalSamples, setTotalSamples] = useState()
 
   useEffect(() => {
-    if (dataset) setTotalSamples(getTotalSamples(dataset.data))
-  }, [dataset])
+    if (myDataset) setTotalSamples(getTotalSamples(myDataset.data))
+  }, [myDataset])
 
   useEffect(() => {
-    if (datasetId) getDataset()
-  }, [datasetId])
+    if (myDatasetId) getDataset()
+  }, [myDatasetId])
 
   const handleClick = () => {
     if (viewport !== 'small') return

--- a/src/components/shared/DatasetActionButton/index.js
+++ b/src/components/shared/DatasetActionButton/index.js
@@ -12,14 +12,14 @@ export const DatasetActionButton = ({
   disableAddRemaining = false,
   ...props
 }) => {
-  const { dataset } = useDatasetManager()
+  const { myDataset } = useDatasetManager()
 
   const {
     getHasAllProcessed,
     anyProcessedSamples,
     getAddedSamples,
     getTotalSamplesInDataset
-  } = useDatasetAction(dataset?.data, data)
+  } = useDatasetAction(myDataset?.data, data)
 
   // shows the disabled add button if no processed samples
   if (!anyProcessedSamples()) {
@@ -27,16 +27,16 @@ export const DatasetActionButton = ({
     return <Button disabled {...props} />
   }
 
-  // shows the remvove from button if all processed samples are in my dataset
+  // shows the remvove from button if all processed samples are in myDataset
   if (getHasAllProcessed()) {
     return <RemoveDatasetButton dataToRemove={getAddedSamples()} />
   }
 
-  // shows the add remaming button if some of the processed samples are in my dataset
+  // shows the add remaming button if some of the processed samples are in myDataset
   if (
     !disableAddRemaining &&
-    dataset?.data &&
-    dataset.data[accessionCode]?.length < downloadableSamples &&
+    myDataset?.data &&
+    myDataset.data[accessionCode]?.length < downloadableSamples &&
     getTotalSamplesInDataset() > 0
   ) {
     return (

--- a/src/components/shared/SamplesTable/ShowOnlyAddedSamplesFilter.js
+++ b/src/components/shared/SamplesTable/ShowOnlyAddedSamplesFilter.js
@@ -5,15 +5,18 @@ import { useSamplesContext } from 'hooks/useSamplesContext'
 import { CheckBox } from 'components/shared/CheckBox'
 
 export const ShowOnlyAddedSamplesFilter = ({ samples }) => {
-  const { dataset } = useDatasetManager()
+  const { myDataset } = useDatasetManager()
   const { updateDatasetId } = useSamplesContext()
-  const { getAnyProcessedInDataset } = useDatasetAction(dataset?.data, samples)
+  const { getAnyProcessedInDataset } = useDatasetAction(
+    myDataset?.data,
+    samples
+  )
   const samplesInMyDataset = getAnyProcessedInDataset()
   const [showOnly, setShowOnly] = useState(false)
 
   const handleToggle = () => {
     const newShowOnly = !showOnly
-    updateDatasetId(newShowOnly ? dataset.id : null)
+    updateDatasetId(newShowOnly ? myDataset.id : null)
     setShowOnly(newShowOnly)
   }
 

--- a/src/contexts/DatasetManagerContext.js
+++ b/src/contexts/DatasetManagerContext.js
@@ -5,12 +5,12 @@ export const DatasetManagerContext = createContext({})
 
 export const DatasetManagerContextProvider = ({ children }) => {
   const {
-    dataset,
-    setDataset,
+    myDataset,
+    setMyDataset,
     datasetAccessions,
     setDatasetAccessions,
-    datasetId,
-    setDatasetId,
+    myDatasetId,
+    setMyDatasetId,
     email,
     setEmail,
     processingDatasets,
@@ -19,24 +19,24 @@ export const DatasetManagerContextProvider = ({ children }) => {
 
   const value = useMemo(
     () => ({
-      dataset,
-      setDataset,
+      myDataset,
+      setMyDataset,
       datasetAccessions,
       setDatasetAccessions,
-      datasetId,
-      setDatasetId,
+      myDatasetId,
+      setMyDatasetId,
       email,
       setEmail,
       processingDatasets,
       setProcessingDatasets
     }),
     [
-      dataset,
-      setDataset,
+      myDataset,
+      setMyDataset,
       datasetAccessions,
       setDatasetAccessions,
-      datasetId,
-      setDatasetId,
+      myDatasetId,
+      setMyDatasetId,
       email,
       setEmail,
       processingDatasets,

--- a/src/contexts/RefinebioContext.js
+++ b/src/contexts/RefinebioContext.js
@@ -10,8 +10,8 @@ import { api } from 'api'
 export const RefinebioContext = createContext({})
 
 export const RefinebioContextProvider = ({ children }) => {
-  const [dataset, setDataset] = useLocalStorage('dataset', {})
-  const [datasetId, setDatasetId] = useLocalStorage('datasetId', null)
+  const [myDataset, setMyDataset] = useLocalStorage('dataset', {})
+  const [myDatasetId, setMyDatasetId] = useLocalStorage('datasetId', null)
   const [email, setEmail] = useLocalStorage('email-address', null)
   const [datasetAccessions, setDatasetAccessions] = useLocalStorage(
     'dataset-accessions',
@@ -59,7 +59,7 @@ export const RefinebioContextProvider = ({ children }) => {
     const oldKeyValue = getOldLocalStorageKey(oldKey)
 
     if (oldKeyValue) {
-      setDatasetId(getOldLocalStorageKey(oldKeyValue))
+      setMyDatasetId(getOldLocalStorageKey(oldKeyValue))
       removeOldLocalStorageKey(oldKey)
     }
   }, [])
@@ -91,12 +91,12 @@ export const RefinebioContextProvider = ({ children }) => {
 
   const value = useMemo(
     () => ({
-      dataset,
-      setDataset,
+      myDataset,
+      setMyDataset,
       datasetAccessions,
       setDatasetAccessions,
-      datasetId,
-      setDatasetId,
+      myDatasetId,
+      setMyDatasetId,
       email,
       setEmail,
       processingDatasets,
@@ -109,12 +109,12 @@ export const RefinebioContextProvider = ({ children }) => {
       waitForToken
     }),
     [
-      dataset,
-      setDataset,
+      myDataset,
+      setMyDataset,
       datasetAccessions,
       setDatasetAccessions,
-      datasetId,
-      setDatasetId,
+      myDatasetId,
+      setMyDatasetId,
       email,
       setEmail,
       processingDatasets,

--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -11,12 +11,12 @@ import { api } from 'api'
 
 export const useDatasetManager = () => {
   const {
-    dataset,
-    setDataset,
+    myDataset,
+    setMyDataset,
     datasetAccessions,
     setDatasetAccessions,
-    datasetId,
-    setDatasetId,
+    myDatasetId,
+    setMyDatasetId,
     email,
     setEmail,
     processingDatasets,
@@ -67,9 +67,9 @@ export const useDatasetManager = () => {
   const clearDataset = async (id = '') => {
     setLoading(true)
     const body = { data: {} }
-    const response = await updateDataset(id || datasetId, body)
+    const response = await updateDataset(id || myDatasetId, body)
 
-    setDataset(response)
+    setMyDataset(response)
     setLoading(false)
   }
 
@@ -79,7 +79,7 @@ export const useDatasetManager = () => {
 
     // stores the newly created dataset ID to localStorge
     if (setCurrentDatasetId) {
-      setDatasetId(response.id)
+      setMyDatasetId(response.id)
     }
 
     return response.id
@@ -100,17 +100,17 @@ export const useDatasetManager = () => {
   }
 
   const getDataset = async (id = '', promiseToken = null) => {
-    if (!id && !datasetId) return null
+    if (!id && !myDatasetId) return null
 
     setLoading(true)
 
     const tokenId = token || promiseToken
     const headers = { ...(tokenId && { 'API-KEY': tokenId }) }
-    const response = await api.dataset.get(id || datasetId, headers)
+    const response = await api.dataset.get(id || myDatasetId, headers)
     const { ok, statusCode } = response
 
     if (ok && isMyDatasetId(id)) {
-      setDataset(response)
+      setMyDataset(response)
     }
 
     // sets the error if any, otherwise resets it
@@ -127,8 +127,8 @@ export const useDatasetManager = () => {
     return response
   }
 
-  // checks if the given dataset ID is My dataset ID
-  const isMyDatasetId = (id) => id === datasetId
+  // checks if the given dataset ID is myDatasetId
+  const isMyDatasetId = (id) => id === myDatasetId
 
   // 'promiseToken' is used for async token resolution (defaults to null)
   // callers must pass 'null' for any optional params to indicate they are not required
@@ -161,10 +161,10 @@ export const useDatasetManager = () => {
     addToProcessingDatasets(processingDatasetId, accessionCode)
     // saves the user's newly entered email or replace the existing one
     setEmail(emailAddress)
-    // deletes the locally saved dataset data once it has started processing (no longer mutable)
+    // deletes the locally saved myDataset data once it has started processing (no longer mutable)
     if (id && isMyDatasetId(id)) {
-      setDataset({})
-      setDatasetId(null)
+      setMyDataset({})
+      setMyDatasetId(null)
     }
 
     return response
@@ -175,7 +175,7 @@ export const useDatasetManager = () => {
     const response = await api.dataset.update(id, body, headers)
 
     if (isMyDatasetId(id)) {
-      setDataset(response)
+      setMyDataset(response)
     }
 
     return response
@@ -209,20 +209,20 @@ export const useDatasetManager = () => {
     setLoading(true)
     const body = { data: {} }
 
-    for (const experiment in dataset.data) {
+    for (const experiment in myDataset.data) {
       if (experimentAccessionCode.includes(experiment)) continue
-      body.data[experiment] = dataset.data[experiment]
+      body.data[experiment] = myDataset.data[experiment]
     }
 
-    const response = await updateDataset(datasetId, body)
-    setDataset(response)
+    const response = await updateDataset(myDatasetId, body)
+    setMyDataset(response)
     setLoading(false)
   }
 
   /* Sample */
   const addSamples = async (data) => {
     setLoading(true)
-    const body = { data: dataset ? { ...dataset.data } : {} }
+    const body = { data: myDataset ? { ...myDataset.data } : {} }
 
     for (const accessionCode of Object.keys(data)) {
       if (data[accessionCode].all) {
@@ -238,10 +238,10 @@ export const useDatasetManager = () => {
     }
 
     const response = await updateDataset(
-      datasetId || (await createDataset(true)),
+      myDatasetId || (await createDataset(true)),
       body
     )
-    setDataset(response)
+    setMyDataset(response)
     setLoading(false)
 
     return response
@@ -254,7 +254,7 @@ export const useDatasetManager = () => {
     isEmptyObject(data) ? 0 : unionizeArrays(...Object.values(data)).length
 
   const removeSamples = async (data) => {
-    const body = { data: { ...dataset.data } }
+    const body = { data: { ...myDataset.data } }
 
     for (const accessionCode of Object.keys(data)) {
       if (!body.data[accessionCode]) continue
@@ -272,15 +272,15 @@ export const useDatasetManager = () => {
     }
 
     setLoading(true)
-    const response = await updateDataset(datasetId, body)
-    setDataset(response)
+    const response = await updateDataset(myDatasetId, body)
+    setMyDataset(response)
     setLoading(false)
   }
 
   const replaceSamples = async (data) => {
     setLoading(true)
-    const response = await updateDataset(datasetId, { data })
-    setDataset(response)
+    const response = await updateDataset(myDatasetId, { data })
+    setMyDataset(response)
     setLoading(false)
   }
 
@@ -291,8 +291,8 @@ export const useDatasetManager = () => {
     setError,
     datasetAccessions,
     setDatasetAccessions,
-    dataset,
-    datasetId,
+    myDataset,
+    myDatasetId,
     loading,
     processingDatasets,
     setProcessingDatasets,

--- a/src/hooks/useRefinebio.js
+++ b/src/hooks/useRefinebio.js
@@ -3,12 +3,12 @@ import { RefinebioContext } from 'contexts/RefinebioContext'
 
 export const useRefinebio = () => {
   const {
-    dataset,
-    setDataset,
+    myDataset,
+    setMyDataset,
     datasetAccessions,
     setDatasetAccessions,
-    datasetId,
-    setDatasetId,
+    myDatasetId,
+    setMyDatasetId,
     email,
     setEmail,
     processingDatasets,
@@ -22,12 +22,12 @@ export const useRefinebio = () => {
   } = useContext(RefinebioContext)
 
   return {
-    dataset,
-    setDataset,
+    myDataset,
+    setMyDataset,
     datasetAccessions,
     setDatasetAccessions,
-    datasetId,
-    setDatasetId,
+    myDatasetId,
+    setMyDatasetId,
     email,
     setEmail,
     processingDatasets,

--- a/src/pages/dataset/[dataset_id].js
+++ b/src/pages/dataset/[dataset_id].js
@@ -31,7 +31,7 @@ export const Dataset = ({ dataset }) => {
   const { isNotProcessed } = getDatasetState(dataset)
 
   useEffect(() => {
-    // redirects users to /download if datasetId matches My dataset ID
+    // redirects users to /download if datasetId matches myDatasetId
     if (isMyDatasetId(dataset.id)) push('/download')
   }, [dataset, start])
 

--- a/src/pages/download/index.js
+++ b/src/pages/download/index.js
@@ -23,7 +23,7 @@ export const Download = () => {
   const {
     query: { start }
   } = useRouter()
-  const { dataset, error, loading, getDataset, getTotalSamples } =
+  const { myDataset, error, loading, getDataset, getTotalSamples } =
     useDatasetManager()
   const { setResponsive } = useResponsive()
   const [isDownloadable, setIsDownloadable] = useState()
@@ -39,12 +39,12 @@ export const Download = () => {
   }, [isDownloadable])
 
   useEffect(() => {
-    if (dataset) {
-      setIsDownloadable(getTotalSamples(dataset.data) > 0)
+    if (myDataset) {
+      setIsDownloadable(getTotalSamples(myDataset.data) > 0)
     } else {
       setIsDownloadable(false)
     }
-  }, [dataset])
+  }, [myDataset])
 
   if (error) {
     return (
@@ -65,7 +65,7 @@ export const Download = () => {
         </Box>
       ) : (
         <Box pad={{ top: 'basex7', bottom: 'large' }}>
-          {dataset && isDownloadable && !start ? (
+          {myDataset && isDownloadable && !start ? (
             <>
               <Row>
                 <Heading
@@ -74,15 +74,15 @@ export const Download = () => {
                 >
                   My Dataset
                 </Heading>
-                <ShareDatasetButton dataset={dataset} />
+                <ShareDatasetButton dataset={myDataset} />
               </Row>
-              <DownloadOptionsForm dataset={dataset} />
-              <FilesSummary dataset={dataset} />
-              <DatasetSummary dataset={dataset} />
-              <DatasetDetails dataset={dataset} />
+              <DownloadOptionsForm dataset={myDataset} />
+              <FilesSummary dataset={myDataset} />
+              <DatasetSummary dataset={myDataset} />
+              <DatasetDetails dataset={myDataset} />
             </>
           ) : start ? (
-            <StartProcessing dataset={dataset} />
+            <StartProcessing dataset={myDataset} />
           ) : (
             <Box
               pad={{


### PR DESCRIPTION
## Issue Number

Closes #392

## Purpose/Implementation Notes

I've updated the `DatasetManagerContext` state names, `dataset`/`setDataset` to `myDataset`/`setMyDataset` and `datasetId`/`setDatasetId` to `myDatasetId`/`setMyDatasetId`, and adjusted the codebase accordingly.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
