### PR TITLE
445 - Implement terms acceptance step on compedium download page

### DIFF
--- a/src/components/Compendia/FileDownloadForm.js
+++ b/src/components/Compendia/FileDownloadForm.js
@@ -1,0 +1,83 @@
+import { useEffect, useState } from 'react'
+import { Heading, Text } from 'grommet'
+import { useRefinebio } from 'hooks/useRefinebio'
+import { useResponsive } from 'hooks/useResponsive'
+import formatBytes from 'helpers/formatBytes'
+import formatString from 'helpers/formatString'
+import { Anchor } from 'components/shared/Anchor'
+import { Button } from 'components/shared/Button'
+import { CheckBox } from 'components/shared/CheckBox'
+import { Column } from 'components/shared/Column'
+import { Row } from 'components/shared/Row'
+import { links } from 'config'
+
+export const FileDownloadForm = ({ compendium }) => {
+  const { setResponsive } = useResponsive()
+  const { acceptedTerms, setAcceptedTerms } = useRefinebio()
+  const [isTermsChecked, setIsTermsChecked] = useState(acceptedTerms)
+  const [submitted, setSubmitted] = useState(false)
+
+  useEffect(() => {
+    if (submitted) {
+      setAcceptedTerms(isTermsChecked)
+    }
+  }, [acceptedTerms, submitted])
+
+  return (
+    <Column align={setResponsive('center', 'start')}>
+      <Heading level={1} margin={{ bottom: 'small' }}>
+        Download the {formatString(compendium.primary_organism_name)} compendium
+      </Heading>
+      <Text>
+        Download size: {formatBytes(compendium.computed_file.size_in_bytes)}
+      </Text>
+      <Row direction={setResponsive('column', 'column', 'row')} width="100%">
+        <Row
+          align={setResponsive('start', 'start', 'center')}
+          direction={setResponsive('column', 'column', 'row')}
+          justify="start"
+          margin={{
+            top: 'small'
+          }}
+          fill
+        >
+          <Column align={setResponsive('center', 'start')}>
+            <CheckBox
+              label={
+                <Text>
+                  I agree to the{' '}
+                  <Anchor
+                    label="Terms of Use"
+                    href={links.terms_of_use}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                </Text>
+              }
+              onClick={() => setIsTermsChecked(!isTermsChecked)}
+            />
+          </Column>
+          <Column
+            align={setResponsive('center', 'start')}
+            margin={{
+              top: setResponsive('medium', 'small', 'none'),
+              left: acceptedTerms
+                ? 'none'
+                : setResponsive('none', 'none', 'medium')
+            }}
+          >
+            <Button
+              label="Download Now"
+              disabled={!isTermsChecked}
+              primary
+              responsive
+              onClick={() => setSubmitted(true)}
+            />
+          </Column>
+        </Row>
+      </Row>
+    </Column>
+  )
+}
+
+export default FileDownloadForm

--- a/src/components/Compendia/FileDownloadForm.js
+++ b/src/components/Compendia/FileDownloadForm.js
@@ -54,7 +54,8 @@ export const FileDownloadForm = ({ compendium }) => {
                   />
                 </Text>
               }
-              onClick={() => setIsTermsChecked(!isTermsChecked)}
+              checked={isTermsChecked}
+              onClick={(e) => setIsTermsChecked(e.target.checked)}
             />
           </Column>
           <Column

--- a/src/components/Compendia/FileDownloadReady.js
+++ b/src/components/Compendia/FileDownloadReady.js
@@ -1,0 +1,34 @@
+import { Heading, Box, Paragraph } from 'grommet'
+import { useResponsive } from 'hooks/useResponsive'
+import formatString from 'helpers/formatString'
+import { Button } from 'components/shared/Button'
+import { Column } from 'components/shared/Column'
+import { Icon } from 'components/shared/Icon'
+
+export const FileDownloadReady = ({ compendium, downloadUrl }) => {
+  const { setResponsive } = useResponsive()
+
+  return (
+    <Column align={setResponsive('center', 'start')}>
+      <Box direction="row" gap="xxsmall" margin={{ bottom: 'small' }}>
+        <Heading level={1}>
+          <Icon color="success" name="Success" /> Downloading{' '}
+          {formatString(compendium.primary_organism_name)} compendium...
+        </Heading>
+      </Box>
+      <Box direction="row" gap="xsmall">
+        <Paragraph>If the download did not start,</Paragraph>
+        {downloadUrl && (
+          <Button
+            label="click here."
+            href={downloadUrl}
+            link
+            linkFontSize="16px"
+          />
+        )}
+      </Box>
+    </Column>
+  )
+}
+
+export default FileDownloadReady

--- a/src/components/Compendia/FileDownloadReady.js
+++ b/src/components/Compendia/FileDownloadReady.js
@@ -1,5 +1,6 @@
 import { Heading, Box, Paragraph } from 'grommet'
 import { useResponsive } from 'hooks/useResponsive'
+import formatBytes from 'helpers/formatBytes'
 import formatString from 'helpers/formatString'
 import { Button } from 'components/shared/Button'
 import { Column } from 'components/shared/Column'
@@ -16,7 +17,10 @@ export const FileDownloadReady = ({ compendium, downloadUrl }) => {
           {formatString(compendium.primary_organism_name)} compendium...
         </Heading>
       </Box>
-      <Box direction="row" gap="xsmall">
+      <Paragraph>
+        Download size: {formatBytes(compendium.computed_file.size_in_bytes)}
+      </Paragraph>
+      <Box direction="row" gap="xsmall" margin={{ top: 'xsmall' }}>
         <Paragraph>If the download did not start,</Paragraph>
         {downloadUrl && (
           <Button

--- a/src/hooks/useDownloadCompendium.js
+++ b/src/hooks/useDownloadCompendium.js
@@ -20,8 +20,10 @@ export const useDownloadCompendium = (compendium) => {
       setDownloadUrl(ok ? response.computed_file.download_url : null)
     }
 
-    if (acceptedTerms) fetchDownloadUrl()
-  }, [compendium, tokenPromise])
+    if (acceptedTerms && tokenPromise) {
+      fetchDownloadUrl()
+    }
+  }, [acceptedTerms, compendium, tokenPromise])
 
   // triggers the file download once the download URL is available
   useEffect(() => {

--- a/src/hooks/useDownloadCompendium.js
+++ b/src/hooks/useDownloadCompendium.js
@@ -11,9 +11,10 @@ export const useDownloadCompendium = (compendium) => {
   // fetchs the download URL for the selected compendium
   useEffect(() => {
     const fetchDownloadUrl = async () => {
+      const resolvedToken = await tokenPromise
       const response = await api.compendia.download(
         compendium.id,
-        await tokenPromise
+        resolvedToken
       )
       const { ok, statusCode } = response
       setError(!ok ? statusCode : null)

--- a/src/pages/compendia/[type]/download/[organism_name].js
+++ b/src/pages/compendia/[type]/download/[organism_name].js
@@ -1,32 +1,29 @@
-import { useEffect } from 'react'
-import { useRouter } from 'next/router'
-import { Box, Heading, Paragraph } from 'grommet'
+import { useEffect, useState } from 'react'
+import { Box } from 'grommet'
 import { useRefinebio } from 'hooks/useRefinebio'
 import { useDownloadCompendium } from 'hooks/useDownloadCompendium'
 import { useResponsive } from 'hooks/useResponsive'
 import { api } from 'api'
 import { compendia } from 'config'
-import { Button } from 'components/shared/Button'
 import { Column } from 'components/shared/Column'
 import { Error } from 'components/shared/Error'
 import { FixedContainer } from 'components/shared/FixedContainer'
-import { Icon } from 'components/shared/Icon'
 import { Row } from 'components/shared/Row'
 import { Explore } from 'components/Compendia/Explore'
-import formatString from 'helpers/formatString'
-import { Spinner } from 'components/shared/Spinner'
+import { FileDownloadForm } from 'components/Compendia/FileDownloadForm'
+import { FileDownloadReady } from 'components/Compendia/FileDownloadReady'
 
 export const DownloadCompendium = ({ compendium }) => {
   const { setResponsive } = useResponsive()
-  const { push, query } = useRouter()
   const { acceptedTerms } = useRefinebio()
   const { error, downloadUrl } = useDownloadCompendium(compendium)
+  const [downloadReady, setDownloadReady] = useState(false)
 
   useEffect(() => {
-    // TODO: File a issue for handling shared links with no token (e.g., modal popup or pre-polulate form)
-    // redirects users to the selected compendia tab if no acceptedTerms
-    if (!acceptedTerms) push(`/compendia/${query.type}`)
-  }, [acceptedTerms])
+    if (acceptedTerms && downloadUrl) {
+      setDownloadReady(true)
+    }
+  }, [acceptedTerms, downloadUrl])
 
   if (error) {
     return (
@@ -41,9 +38,6 @@ export const DownloadCompendium = ({ compendium }) => {
     )
   }
 
-  // shows Spinner until the download URL is ready
-  if (!downloadUrl) return <Spinner />
-
   return (
     <FixedContainer>
       <Box
@@ -53,27 +47,15 @@ export const DownloadCompendium = ({ compendium }) => {
           bottom: 'xlarge'
         }}
       >
-        <Row justify="center" width={setResponsive('100%', '70%')}>
-          <Column align={setResponsive('center', 'start')}>
-            <Box direction="row" gap="xxsmall" margin={{ bottom: 'small' }}>
-              <Heading level={1}>
-                <Icon color="success" name="Success" /> Downloading{' '}
-                {formatString(compendium.primary_organism_name || '')}{' '}
-                compendium...
-              </Heading>
-            </Box>
-            <Box direction="start" gap="xsmall">
-              <Paragraph>If the download did not start,</Paragraph>
-              {downloadUrl && (
-                <Button
-                  label="click here."
-                  href={downloadUrl}
-                  link
-                  linkFontSize="16px"
-                />
-              )}
-            </Box>
-          </Column>
+        <Row justify="center" width={setResponsive('100%', '85%')}>
+          {downloadReady ? (
+            <FileDownloadReady
+              compendium={compendium}
+              downloadUrl={downloadUrl}
+            />
+          ) : (
+            <FileDownloadForm compendium={compendium} />
+          )}
           <Column
             align="center"
             margin={{


### PR DESCRIPTION
## Issue Number

Closes #445

## Purpose/Implementation Notes

I've add the terms acceptance step when no valid token is present, and removed the temporary redirect from the compendium file download page.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
