### PR TITLE
503 - Fix dataset ID undefined in startProcessingDataset with dataset ID validation

### DIFF
--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -142,7 +142,9 @@ export const useDatasetManager = () => {
       start: true
     }
 
-    const processingDatasetId = id || (await createDataset()) // creates new dataset ID for one-off download
+    const processingDatasetId = isMyDatasetId(id)
+      ? myDatasetId
+      : await createDataset() // creates new dataset ID for one-off download and shared dataset
     const response = await updateDataset(processingDatasetId, body)
     // adds this dataset ID to processingDatasets[] for polling
     addToProcessingDatasets(processingDatasetId, accessionCode)


### PR DESCRIPTION
## Issue Number

Closes #503

## Purpose/Implementation Notes

I've fixed the dataset ID `undefined` bug in the `startProcessingDataset` method of `useDatasetManager`.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
