### PR TITLE
526 - Update Compendia Download Page Links

### DIFF
--- a/src/components/CompendiaExplore.js
+++ b/src/components/CompendiaExplore.js
@@ -17,17 +17,25 @@ const ListItem = ({ href, text }) => (
   </Box>
 )
 
-export const CompendiaExplore = () => {
+export const CompendiaExplore = ({ type }) => {
   const { setResponsive } = useResponsive()
+
+  const isNormalized = type === 'normalized'
+  const linkText = `Learn how the normalized ${
+    isNormalized ? 'normalized' : 'RNA-seq'
+  } compendia are created`
+  const linkHerf = isNormalized
+    ? links.refinebio_docs_learn_how_the_normalized_compendia_are_created
+    : links.refinebio_docs_learn_how_the_rna_seq_compendia_are_created
 
   const exploreLinks = [
     {
-      text: ' Get started with the species compendia',
-      href: links.refinebio_docs_getting_started_with_species_compendia
+      text: 'Get started with the refine.bio compendia',
+      href: links.refinebio_docs_getting_started_with_refinebio_compendia
     },
     {
-      text: 'Learn how the species compendia are created',
-      href: links.refinebio_docs_species_compendia
+      text: linkText,
+      href: linkHerf
     },
     {
       text: 'See our exploratory analyses in test species compendia',

--- a/src/components/CompendiaExplore.js
+++ b/src/components/CompendiaExplore.js
@@ -21,9 +21,9 @@ export const CompendiaExplore = ({ type }) => {
   const { setResponsive } = useResponsive()
 
   const isNormalized = type === 'normalized'
-  const linkText = `Learn how the normalized ${
-    isNormalized ? 'normalized' : 'RNA-seq'
-  } compendia are created`
+  const learnHowLinkText = isNormalized
+    ? 'Learn how the normalized compendia are created'
+    : 'Learn how the RNA-seq compendia are created'
   const linkHerf = isNormalized
     ? links.refinebio_docs_learn_how_the_normalized_compendia_are_created
     : links.refinebio_docs_learn_how_the_rna_seq_compendia_are_created
@@ -34,7 +34,7 @@ export const CompendiaExplore = ({ type }) => {
       href: links.refinebio_docs_getting_started_with_refinebio_compendia
     },
     {
-      text: linkText,
+      text: learnHowLinkText,
       href: linkHerf
     },
     {

--- a/src/config/links.js
+++ b/src/config/links.js
@@ -25,10 +25,12 @@ export const links = {
     'https://docs.refine.bio/en/latest/main_text.html#aggregations',
   refinebio_docs_collapsing_by_genus:
     'https://docs.refine.bio/en/latest/main_text.html#collapsing-by-genus',
-  refinebio_docs_getting_started_with_species_compendia:
-    'https://docs.refine.bio/en/latest/getting_started.html#getting-started-with-species-compendia',
-  refinebio_docs_species_compendia:
-    'https://docs.refine.bio/en/latest/main_text.html#species-compendia',
+  refinebio_docs_getting_started_with_refinebio_compendia:
+    'https://docs.refine.bio/en/latest/getting_started.html#getting-started-with-normalized-compendia',
+  refinebio_docs_learn_how_the_normalized_compendia_are_created:
+    'https://docs.refine.bio/en/latest/main_text.html#normalized-compendia',
+  refinebio_docs_learn_how_the_rna_seq_compendia_are_created:
+    'https://docs.refine.bio/en/latest/main_text.html#rna-seq-sample-compendia',
   refinebio_docs_harmonized_metadata:
     'https://docs.refine.bio/en/latest/main_text.html#refine-bio-harmonized-metadata',
   refinebio_docs_normalized_compendia:

--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -93,7 +93,7 @@ export const useDatasetManager = () => {
     window.location.href = response.download_url
   }
 
-  const getDataset = async (id) => {
+  const getDataset = async (id = myDatasetId) => {
     if (!id && !myDatasetId) return null // TODO: Throw an error
 
     setLoading(true)

--- a/src/pages/compendia/[type]/download/[organismName].js
+++ b/src/pages/compendia/[type]/download/[organismName].js
@@ -13,7 +13,7 @@ import { Error } from 'components/Error'
 import { FixedContainer } from 'components/FixedContainer'
 import { Row } from 'components/Row'
 
-export const DownloadCompendium = ({ compendium }) => {
+export const DownloadCompendium = ({ compendium, type }) => {
   const { setResponsive } = useResponsive()
   const { acceptedTerms } = useRefinebio()
   const { error, downloadUrl } = useDownloadCompendium(compendium)
@@ -80,7 +80,7 @@ export const DownloadCompendium = ({ compendium }) => {
         </Row>
       </Box>
       <Box>
-        <CompendiaExplore />
+        <CompendiaExplore type={type} />
       </Box>
     </FixedContainer>
   )
@@ -107,7 +107,8 @@ export const getServerSideProps = async ({ query }) => {
 
     return {
       props: {
-        compendium
+        compendium,
+        type
       }
     }
   }


### PR DESCRIPTION
## Issue Number

Closes #526  

I've also updated the links in the **QA Compendia - Compendium Download**(#515) checklist.

## Purpose/Implementation Notes

I've updated the following resource links on the compendium download page: 

Previously `Get started with the species compendia`:

- [Get started with the refine.bio compendia](https://docs.refine.bio/en/latest/getting_started.html#getting-started-with-normalized-compendia) 

Previously `Learn how the species compendia are created`:

**Normalized Only**
- [Learn how the normalized compendia are created](https://docs.refine.bio/en/latest/main_text.html#normalized-compendia)

**RNA-seq Only**
- [Learn how the RNA-seq compendia are created](https://docs.refine.bio/en/latest/main_text.html#rna-seq-sample-compendia)

**NOTE:** Instead of using the `CompendiaContextProvider` and its hook `useCompendia`, I've leveraged the `type` prop from `getServerSideProps` for simplicity. Thank you!

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
