### PR TITLE
535 - Fix Chrome compatibility Issue with one-off experiment download

### DIFF
--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -126,7 +126,7 @@ export const useDatasetManager = () => {
   }
 
   // checks if the given dataset ID is myDatasetId
-  const isMyDatasetId = (id) => id === myDatasetId
+  const isMyDatasetId = (id) => myDatasetId !== null && id === myDatasetId
 
   const startProcessingDataset = async (
     options,
@@ -145,11 +145,14 @@ export const useDatasetManager = () => {
     const processingDatasetId = isMyDatasetId(id)
       ? myDatasetId
       : await createDataset() // creates new dataset ID for one-off download and shared dataset
+
     const response = await updateDataset(processingDatasetId, body)
+
     // adds this dataset ID to processingDatasets[] for polling
     addToProcessingDatasets(processingDatasetId, accessionCode)
     // saves the user's newly entered email or replace the existing one
     setEmail(options.email_address)
+
     // deletes the locally saved dataset data once it has started processing (no longer mutable)
     if (id && isMyDatasetId(id)) {
       setMyDataset({})


### PR DESCRIPTION
## Issue Number

Closes #535 

## Purpose/Implementation Notes

I've fixed the Chrome issue with one-off experiment downloads. Now, a valid dataset ID is included in the request and one-off experiments can be downloaded in all browsers.


<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
