### PR TITLE
543 - Fix duplicate dataset IDs when regenerating a datase

### DIFF
--- a/src/components/DatasetStartProcessingForm.js
+++ b/src/components/DatasetStartProcessingForm.js
@@ -33,15 +33,7 @@ export const DatasetStartProcessingForm = ({ dataset }) => {
       }
     }
 
-    const downloadOptions = {
-      aggregate_by: dataset.aggregate_by,
-      data: dataset.data,
-      scale_by: dataset.scale_by,
-      quantile_normalize: dataset.quantile_normalize,
-      ...formValues
-    }
-
-    const { id } = await startProcessingDataset(downloadOptions, dataset.id)
+    const { id } = await startProcessingDataset(formValues, dataset.id)
     const pathname = `/dataset/${id}`
     push({ pathname }, pathname)
     gtag.trackDatasetDownloadOptions(dataset)
@@ -54,6 +46,10 @@ export const DatasetStartProcessingForm = ({ dataset }) => {
   return (
     <Formik
       initialValues={{
+        aggregate_by: dataset.aggregate_by,
+        data: dataset.data,
+        scale_by: dataset.scale_by,
+        quantile_normalize: dataset.quantile_normalize,
         email_address: email || '',
         email_ccdl_ok: true,
         terms: acceptedTerms

--- a/src/components/DatasetStartProcessingForm.js
+++ b/src/components/DatasetStartProcessingForm.js
@@ -34,7 +34,10 @@ export const DatasetStartProcessingForm = ({ dataset }) => {
     }
 
     const downloadOptions = {
+      aggregate_by: dataset.aggregate_by,
       data: dataset.data,
+      scale_by: dataset.scale_by,
+      quantile_normalize: dataset.quantile_normalize,
       ...formValues
     }
 

--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -144,7 +144,7 @@ export const useDatasetManager = () => {
 
     const processingDatasetId = isMyDatasetId(id)
       ? myDatasetId
-      : await createDataset() // creates new dataset ID for one-off download and shared dataset
+      : id || (await createDataset()) // creates new dataset ID for one-off download and shared dataset
 
     const response = await updateDataset(processingDatasetId, body)
 

--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -144,7 +144,7 @@ export const useDatasetManager = () => {
 
     const processingDatasetId = isMyDatasetId(id)
       ? myDatasetId
-      : id || (await createDataset()) // creates new dataset ID for one-off download and shared dataset
+      : id || (await createDataset()) // creates a new dataset ID for one-off download or shared dataset
 
     const response = await updateDataset(processingDatasetId, body)
 

--- a/src/hooks/useDatasetManager.js
+++ b/src/hooks/useDatasetManager.js
@@ -142,9 +142,7 @@ export const useDatasetManager = () => {
       start: true
     }
 
-    const processingDatasetId = isMyDatasetId(id)
-      ? myDatasetId
-      : id || (await createDataset()) // creates a new dataset ID for one-off download or shared dataset
+    const processingDatasetId = id || (await createDataset()) // creates a new dataset ID for one-off download
 
     const response = await updateDataset(processingDatasetId, body)
 


### PR DESCRIPTION
## Issue Number

Closes #543

## Purpose/Implementation Notes

I've fixed the bug in the dataset regeneration process and prevented duplicate dataset ID generation.

## Types of changes


- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
