### PR TITLE
540 - Remove duplicated "Learn more" text in Download Files Summary 

### DIFF
--- a/src/components/DatasetFileSummaries.js
+++ b/src/components/DatasetFileSummaries.js
@@ -73,7 +73,7 @@ export const DatasetFileSummaries = ({ dataset }) => {
         label={
           <>
             All data you download from refine.bio has been uniformly processed
-            and normalized. Learn more.{' '}
+            and normalized.{' '}
             <Anchor
               href={links.refinebio_docs_standard_pipeline}
               label="Learn More"


### PR DESCRIPTION
## Issue Number
Closes #540

## Purpose/Implementation Notes

I've removed the duplicated "Learn more" text in the download files summary.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
