### PR TITLE
536 - Remove Alternate Accession IDs links for E-GEOD

### DIFF
--- a/src/components/ExperimentCardBody.js
+++ b/src/components/ExperimentCardBody.js
@@ -19,7 +19,7 @@ export const ExperimentCardBody = ({ experiment, charLimit = 300 }) => {
   const [toggleDesciption, setToggleDescription] = useState(
     description.length > charLimit
   )
-  const isArrayExpress =
+  const isGEOD =
     alternateAccessionCode && alternateAccessionCode.startsWith('E-GEOD')
 
   return (
@@ -97,7 +97,7 @@ export const ExperimentCardBody = ({ experiment, charLimit = 300 }) => {
           Alternate Accession IDs
         </Heading>
         {alternateAccessionCode ? (
-          isArrayExpress ? (
+          isGEOD ? (
             <TextHighlight>{alternateAccessionCode}</TextHighlight>
           ) : (
             <Anchor

--- a/src/components/ExperimentCardBody.js
+++ b/src/components/ExperimentCardBody.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-nested-ternary */
 import { useState } from 'react'
 import { Box, Heading, Paragraph, Text } from 'grommet'
 import { useDatasetManager } from 'hooks/useDatasetManager'
@@ -18,6 +19,8 @@ export const ExperimentCardBody = ({ experiment, charLimit = 300 }) => {
   const [toggleDesciption, setToggleDescription] = useState(
     description.length > charLimit
   )
+  const isArrayExpress =
+    alternateAccessionCode && alternateAccessionCode.startsWith('E-GEOD')
 
   return (
     <Box pad={{ top: 'medium', bottom: 'small' }}>
@@ -94,11 +97,15 @@ export const ExperimentCardBody = ({ experiment, charLimit = 300 }) => {
           Alternate Accession IDs
         </Heading>
         {alternateAccessionCode ? (
-          <Anchor
-            href={getURLForAccessionCode(alternateAccessionCode)}
-            target="_blank"
-            label={<TextHighlight>{alternateAccessionCode}</TextHighlight>}
-          />
+          isArrayExpress ? (
+            <TextHighlight>{alternateAccessionCode}</TextHighlight>
+          ) : (
+            <Anchor
+              href={getURLForAccessionCode(alternateAccessionCode)}
+              target="_blank"
+              label={<TextHighlight>{alternateAccessionCode}</TextHighlight>}
+            />
+          )
         ) : (
           <TextNull text="None" />
         )}

--- a/src/components/ExperimentDetail.js
+++ b/src/components/ExperimentDetail.js
@@ -20,6 +20,9 @@ export const ExperimentDetail = ({ experiment }) => {
   const { setResponsive } = useResponsive()
   const { navigateToSearch } = useSearchManager()
 
+  const alternateAccessionCode = experiment.alternate_accession_code
+  const isArrayExpress = alternateAccessionCode.startsWith('E-GEOD')
+
   return (
     <FixedContainer>
       <Box elevation="medium" pad="large" margin={{ bottom: 'basex6' }}>
@@ -169,21 +172,21 @@ export const ExperimentDetail = ({ experiment }) => {
             <InformationItem
               field="Alternate Accession IDs"
               value={
-                <Anchor
-                  label={
-                    <TextHighlight>
-                      {experiment.alternate_accession_code}
-                    </TextHighlight>
-                  }
-                  href={getURLForAccessionCode(
-                    experiment.alternate_accession_code
-                  )}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                />
+                isArrayExpress ? (
+                  <TextHighlight>{alternateAccessionCode}</TextHighlight>
+                ) : (
+                  <Anchor
+                    label={
+                      <TextHighlight>{alternateAccessionCode}</TextHighlight>
+                    }
+                    href={getURLForAccessionCode(alternateAccessionCode)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  />
+                )
               }
               fallback="None"
-              forceFallback={!experiment.alternate_accession_code}
+              forceFallback={!alternateAccessionCode}
             />
           </InformationList>
         </Box>


### PR DESCRIPTION
## Issue Number

Closes #536

## Purpose/Implementation Notes

I've unlinked the alternative accession IDs for `E-GEOD*`.  

Please see the latest preview [here](https://refinebio-gid8x9q45-ccdl.vercel.app/search)

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
