### PR TITLE
551 - Add default sorting by accession_code for the samples table fetching

### DIFF
--- a/src/components/DataTable.js
+++ b/src/components/DataTable.js
@@ -26,6 +26,7 @@ export const DataTable = ({
   columns: tableColumns,
   data: tableData,
   defaultColumn = {},
+  defaultSortId = '',
   hasTableData,
   hiddenColumns = [],
   manualPagination = false,
@@ -53,7 +54,15 @@ export const DataTable = ({
       columns,
       data,
       defaultColumn,
-      initialState: { hiddenColumns },
+      initialState: {
+        hiddenColumns,
+        sortBy: [
+          {
+            id: defaultSortId,
+            desc: false
+          }
+        ]
+      },
       manualPagination,
       autoResetSortBy: false
     },

--- a/src/components/SamplesTable.js
+++ b/src/components/SamplesTable.js
@@ -215,6 +215,7 @@ export const SamplesTable = ({
               columns={columns}
               data={data || []}
               defaultColumn={defaultColumn}
+              defaultSortId="accession_code"
               hasTableData={hasSamples}
               hiddenColumns={columns
                 .filter((column) => column.isVisible === false)

--- a/src/hooks/useSamplesContext.js
+++ b/src/hooks/useSamplesContext.js
@@ -73,7 +73,8 @@ export const useSamplesContext = () => {
       if (newSortBy) {
         updatedQuery.ordering = newSortBy
       } else {
-        delete updatedQuery.ordering
+        // fetch with accession code by default
+        updatedQuery.ordering = 'accession_code'
       }
 
       return updatedQuery


### PR DESCRIPTION
## Issue Number

Closes #551

## Purpose/Implementation Notes

I've add default sorting by `accession_code` for the samples table data fetch to prevent the API from returning the same sample as the last record in the table.

When the table first loads, the data is sorted in ascending order by `accession_code` and the `Accession Code` column header highlights an ascending sort arrow to indicate that to users. Once a user applies sorting on any other column, the default indicator is removed and the sorting behavior and arrow styles function as usual. 

Please see the latest UI [here]()

## Types of changes

What types of changes does your code introduce?

<!-- Remove any which your PR isn't -->

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
