### PR TITLE
553 - Fix Download Files Summary Component

### DIFF
--- a/src/helpers/getDownloadFilesData.js
+++ b/src/helpers/getDownloadFilesData.js
@@ -1,12 +1,12 @@
 import getReadable from 'helpers/getReadable'
-// metadata info of a download https://github.com/AlexsLemonade/refinebio-frontend/issues/25#issuecomment-395870627
-// Returns the file size estimates of the given dataset and its aggregate_by value (either 'EXPERIMENT' or 'SPECIES')
+// Docs: https://docs.refine.bio/en/latest/main_text.html#downloadable-files
+// The UI reflects the contents of the downloaded zip files as listed in the doc.
 export default (dataset) => {
   const aggregateBy = getReadable(dataset.aggregate_by)
-  const isExperiment = aggregateBy === 'Experiment'
   const totalExperiments = Object.keys(dataset.data).length
   const totalSpecies = Object.keys(dataset.organism_samples).length
-  const totalCount = isExperiment ? totalExperiments : totalSpecies
+  const totalCount =
+    aggregateBy === 'Experiment' ? totalExperiments : totalSpecies
 
   return {
     files: [
@@ -16,15 +16,13 @@ export default (dataset) => {
         format: 'tsv'
       },
       {
-        title: `${totalExperiments} Sample Metadata Files`,
-        description: '1 file per Experiment',
+        title: `${totalCount} Sample Metadata Files`,
+        description: `1 file per ${aggregateBy}`,
         format: 'tsv'
       },
       {
-        title: `${totalCount} ${aggregateBy} Metadata ${
-          isExperiment ? 'Files' : ''
-        }`,
-        description: `1 file per ${aggregateBy}`,
+        title: '1 Aggregate Metadata File',
+        description: '1 file per download',
         format: 'json'
       }
     ]

--- a/src/helpers/getDownloadFilesData.js
+++ b/src/helpers/getDownloadFilesData.js
@@ -21,7 +21,7 @@ export default (dataset) => {
         format: 'tsv'
       },
       {
-        title: '1 Aggregate Metadata File',
+        title: `1 ${aggregateBy} Metadata File`,
         description: '1 file per download',
         format: 'json'
       }


### PR DESCRIPTION
## Issue Number

Closes #553

## Purpose/Implementation Notes

I've adjust the `Download Files Summary` UI to match the contents of the downloaded zip files. 

@dvenprasad, please see the latest UI [here](https://refinebio-web-git-nozomione-553-fix-download-files-793c00-ccdl.vercel.app/) -  It aligns with the download folder structure listed in the [docs](https://docs.refine.bio/en/latest/main_text.html#downloadable-files). Thank you! 

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
