### PR TITLE
309 - Setup GA definitions / filters / collections for Production in Google Analytics Account 

### DIFF
--- a/src/analytics/gtag.js
+++ b/src/analytics/gtag.js
@@ -47,7 +47,7 @@ const trackDownloadNormalizedCompendia = (compendia) => {
 const trackDatasetAction = (Component) => {
   const payload = {}
   payload.dataset_action = Component.name
-  event('dataset_action', payload)
+  event('click_dataset_action', payload)
 }
 // tracks the number of dataset downloads by dataset ID
 const trackDatasetDownload = (dataset) => {
@@ -59,12 +59,12 @@ const trackDatasetDownload = (dataset) => {
 const trackDatasetDownloadOptions = (dataset) => {
   const payload = {}
   payload.dataset_download_options = getFormattedDatasetOptions(dataset)
-  event('dataset_download_options', payload)
+  event('set_dataset_download_options', payload)
 }
 // tracks the number of one-off downloads by accession code
 const trackOneOffExperimentDownload = (experiment) => {
   const payload = {}
-  payload.one_off_experiment_download = experiment.accession_code
+  payload.experiment_accession_code = experiment.accession_code
   event('one_off_experiment_download', payload)
 }
 // tracks the dataset's state (expired or valid) and download options change (initial and updated)
@@ -80,7 +80,7 @@ const trackRegeneratedDataset = (dataset, regeneratedDataset) => {
 // tracks user clicks on the share dataset button by dataset ID
 const trackSharedDataset = (dataset) => {
   const payload = {}
-  payload.shared_dataset_id = dataset.id
+  payload.dataset_id = dataset.id
   event('shared_dataset', payload)
 }
 
@@ -90,14 +90,14 @@ const trackSharedDataset = (dataset) => {
 const trackExperimentPageClick = (Component) => {
   const payload = {}
   payload.experiment_page_click_from = Component.name
-  event('page_view', payload)
+  event('click_experiment_page', payload)
 }
 // tracks the explore links that users click on after downloads
 const trackExploredUsageClick = (link) => {
   // sets the dimension key for dataset or compendia usage
   const payload = {}
   payload.explored_usage_link = link
-  event(`click`, payload)
+  event(`click_explored_usage_link`, payload)
 }
 // tracks internal and external link clicks
 const trackLink = (link) => {
@@ -132,7 +132,7 @@ const trackFilterType = (type) => {
 const trackToggleFilterItem = (isChecked, item) => {
   const payload = {}
   payload.toggled_filter_item = getToggledFilterItem(isChecked, item)
-  event('toggled_filter_item', payload)
+  event('toggle_filter_item', payload)
 }
 
 const trackSearchQuery = (query) => {

--- a/src/analytics/helpers.js
+++ b/src/analytics/helpers.js
@@ -15,18 +15,20 @@ const supportedEvents = [
   'compendia_rnaseq_download',
   'compendia_normalized_download',
   // Dataset
+  'click_dataset_action',
   'dataset_download',
-  'dataset_action',
-  'dataset_download_options',
+  'set_dataset_download_options',
   'one_off_experiment_download',
   'regenerated_dataset',
   'shared_dataset',
   // Links
+  'click_experiment_page',
+  'click_explored_usage_link',
   'click_external_link',
   'click_internal_link',
   // Search
   'filter_type',
-  'toggled_filter_item',
+  'toggle_filter_item',
   'search_text'
 ]
 const supportedDimensions = [
@@ -39,7 +41,7 @@ const supportedDimensions = [
   'dataset_action',
   'dataset_download_options',
   'dataset_id',
-  'one_off_experiment_download',
+  'experiment_accession_code',
   'regenerated_download_options_change',
   'regenerated_state',
   // Links
@@ -51,7 +53,6 @@ const supportedDimensions = [
   'filter_combination',
   'filter_type',
   'toggled_filter_item',
-  'shared_dataset_id',
   'search_text'
 ]
 export const event = (eventName, value = {}, nonInteraction = false) => {


### PR DESCRIPTION
## Issue Number

Closes #309

## Purpose/Implementation Notes

I've set up the `Refine.bio Web` property for `production` in Google Analytics, and made minor adjustments to the custom event and dimension related to dataset and one-off downloads, filters, and click events.

## Types of changes

- Refactor (addresses code organization and design mentioned in corresponding issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [ ] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
