### PR TITLE
Add the displayName to components passed to custom events for Analytics in Production 

### DIFF
--- a/src/components/AddRemainingDatasetButton.js
+++ b/src/components/AddRemainingDatasetButton.js
@@ -33,4 +33,6 @@ export const AddRemainingDatasetButton = ({ dataToAdd, samplesInDataset }) => {
   )
 }
 
+AddRemainingDatasetButton.displayName = 'AddRemainingDatasetButton'
+
 export default AddRemainingDatasetButton

--- a/src/components/AddToDatasetButton.js
+++ b/src/components/AddToDatasetButton.js
@@ -22,4 +22,6 @@ export const AddToDatasetButton = ({ dataToAdd, ...props }) => {
   )
 }
 
+AddToDatasetButton.displayName = 'AddToDatasetButton'
+
 export default AddToDatasetButton

--- a/src/components/DatasetStartProcessingForm.js
+++ b/src/components/DatasetStartProcessingForm.js
@@ -113,4 +113,6 @@ export const DatasetStartProcessingForm = ({ dataset }) => {
   )
 }
 
+DatasetStartProcessingForm.displayName = 'DatasetStartProcessingForm'
+
 export default DatasetStartProcessingForm

--- a/src/components/DownloadDatasetModal.js
+++ b/src/components/DownloadDatasetModal.js
@@ -157,4 +157,6 @@ export const DownloadDatasetModal = ({ dataset, id, closeModal }) => {
   )
 }
 
+DownloadDatasetModal.displayName = 'DownloadDatasetModal'
+
 export default DownloadDatasetModal

--- a/src/components/DownloadNowModal.js
+++ b/src/components/DownloadNowModal.js
@@ -169,4 +169,6 @@ export const DownloadNowModal = ({
   )
 }
 
+DownloadNowModal.displayName = 'DownloadNowModal'
+
 export default DownloadNowModal

--- a/src/components/ExperimentCardFooter.js
+++ b/src/components/ExperimentCardFooter.js
@@ -23,4 +23,6 @@ export const ExperimentCardFooter = ({ experiment }) => {
   )
 }
 
+ExperimentCardFooter.displayName = 'ExperimentCardFooter'
+
 export default ExperimentCardFooter

--- a/src/components/ExperimentCardHeader.js
+++ b/src/components/ExperimentCardHeader.js
@@ -49,4 +49,6 @@ export const ExperimentCardHeader = ({ experiment, isLinked = false }) => {
   )
 }
 
+ExperimentCardHeader.displayName = 'ExperimentCardHeader'
+
 export default ExperimentCardHeader

--- a/src/components/MoveToDatasetButton.js
+++ b/src/components/MoveToDatasetButton.js
@@ -82,4 +82,6 @@ export const MoveToDatasetButton = ({ dataset }) => {
   )
 }
 
+MoveToDatasetButton.displayName = 'MoveToDatasetButton'
+
 export default MoveToDatasetButton

--- a/src/components/RemoveAllButton.js
+++ b/src/components/RemoveAllButton.js
@@ -62,4 +62,6 @@ export const RemoveAllButton = () => {
   )
 }
 
+RemoveAllButton.displayName = 'RemoveAllButton'
+
 export default RemoveAllButton

--- a/src/components/RemoveDatasetButton.js
+++ b/src/components/RemoveDatasetButton.js
@@ -35,4 +35,6 @@ export const RemoveDatasetButton = ({ dataToRemove }) => {
   )
 }
 
+RemoveDatasetButton.displayName = 'RemoveDatasetButton'
+
 export default RemoveDatasetButton

--- a/src/components/SignUpBlock.js
+++ b/src/components/SignUpBlock.js
@@ -111,4 +111,6 @@ export const SignUpBlock = () => {
   )
 }
 
+SignUpBlock.displayName = 'SignUpBlock'
+
 export default SignUpBlock


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

I've added the `displayName` property to components that are passed into custom events for `gtag` to prevent incorrect data from being collected in Analytics custom reports.

In `production`, minification of the component names results in incorrect event data, where minified components names (e.g., `e`) are tracked instead of the actual component names (e.g., `AddToDatasetButton`).


## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

N/A

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

Minified component name:

![Screenshot 2025-05-28 at 9 40 19 AM](https://github.com/user-attachments/assets/4b0758ef-911c-4b11-b9d0-a67c23f66ec3)

Actual component name:

![Screenshot 2025-05-28 at 9 40 39 AM](https://github.com/user-attachments/assets/c01aac53-69fb-4529-a0a2-31adac1e0057)


