### PR TITLE
Update gtag custom event parameter to accept component name strings for GA4

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,8 +4,6 @@
 // Vercel for GitHub:
 // https://vercel.com/docs/concepts/git/vercel-for-github#configuring-for-github
 
-// eslint-disable-next-line import/no-extraneous-dependencies
-const TerserPlugin = require('terser-webpack-plugin')
 const { withSentryConfig } = require('@sentry/nextjs')
 
 const moduleExports = () => {
@@ -57,22 +55,7 @@ const moduleExports = () => {
       hideSourceMaps: true
     },
     swcMinify: true,
-    webpack(baseConfig) {
-      const config = { ...baseConfig }
-      // Keep component names for GA4 tracking in production
-      if (isProduction) {
-        config.optimization = {
-          ...config.optimization,
-          minimizer: [
-            ...config.optimization.minimizer,
-            new TerserPlugin({
-              terserOptions: {
-                keep_fnames: true
-              }
-            })
-          ]
-        }
-      }
+    webpack(config) {
       return config
     }
   }

--- a/src/analytics/gtag.js
+++ b/src/analytics/gtag.js
@@ -13,9 +13,9 @@ import {
 
 /* --- General --- */
 // tracks email subscriptions and the user-subscribed location
-const trackEmailSubscription = (Component) => {
+const trackEmailSubscription = (componentName) => {
   const payload = {}
-  payload.subscription_click_from = Component.name
+  payload.subscription_click_from = componentName
   event('email_subscription', payload)
 }
 
@@ -44,9 +44,9 @@ const trackDownloadNormalizedCompendia = (compendia) => {
 
 /* --- Datasets --- */
 // tracks user clicks on the dataset actions buttons
-const trackDatasetAction = (Component) => {
+const trackDatasetAction = (componentName) => {
   const payload = {}
-  payload.dataset_action = Component.name
+  payload.dataset_action = componentName
   event('click_dataset_action', payload)
 }
 // tracks the number of dataset downloads by dataset ID
@@ -87,9 +87,9 @@ const trackSharedDataset = (dataset) => {
 /* --- Links --- */
 // tracks click-through to the experiment page from search results
 // used to create a report to differentiate which component users click
-const trackExperimentPageClick = (Component) => {
+const trackExperimentPageClick = (componentName) => {
   const payload = {}
-  payload.experiment_page_click_from = Component.name
+  payload.experiment_page_click_from = componentName
   event('click_experiment_page', payload)
 }
 // tracks the explore links that users click on after downloads

--- a/src/components/AddRemainingDatasetButton.js
+++ b/src/components/AddRemainingDatasetButton.js
@@ -9,7 +9,7 @@ export const AddRemainingDatasetButton = ({ dataToAdd, samplesInDataset }) => {
 
   const handleClick = () => {
     addSamples(dataToAdd)
-    gtag.trackDatasetAction(AddRemainingDatasetButton)
+    gtag.trackDatasetAction('AddRemainingDatasetButton')
   }
 
   return (

--- a/src/components/AddToDatasetButton.js
+++ b/src/components/AddToDatasetButton.js
@@ -7,7 +7,7 @@ export const AddToDatasetButton = ({ dataToAdd, ...props }) => {
 
   const handleClick = () => {
     addSamples(dataToAdd)
-    gtag.trackDatasetAction(AddToDatasetButton)
+    gtag.trackDatasetAction('AddToDatasetButton')
   }
 
   return (

--- a/src/components/DatasetStartProcessingForm.js
+++ b/src/components/DatasetStartProcessingForm.js
@@ -29,7 +29,7 @@ export const DatasetStartProcessingForm = ({ dataset }) => {
         formValues.email_address
       )
       if (subscribeEmailResponse.status !== 'error') {
-        gtag.trackEmailSubscription(DatasetStartProcessingForm)
+        gtag.trackEmailSubscription('DatasetStartProcessingForm')
       }
     }
 

--- a/src/components/DownloadDatasetModal.js
+++ b/src/components/DownloadDatasetModal.js
@@ -30,7 +30,7 @@ export const DownloadDatasetModal = ({ dataset, id, closeModal }) => {
         formValues.email_address
       )
       if (subscribeEmailResponse.status !== 'error') {
-        gtag.trackEmailSubscription(DownloadDatasetModal)
+        gtag.trackEmailSubscription('DownloadDatasetModal')
       }
     }
 

--- a/src/components/DownloadNowModal.js
+++ b/src/components/DownloadNowModal.js
@@ -33,7 +33,7 @@ export const DownloadNowModal = ({
         formValues.email_address
       )
       if (subscribeEmailResponse.status !== 'error') {
-        gtag.trackEmailSubscription(DownloadNowModal)
+        gtag.trackEmailSubscription('DownloadNowModal')
       }
     }
 

--- a/src/components/ExperimentCardFooter.js
+++ b/src/components/ExperimentCardFooter.js
@@ -9,7 +9,7 @@ export const ExperimentCardFooter = ({ experiment }) => {
   const { push } = useRouter()
 
   const handleClick = () => {
-    gtag.trackExperimentPageClick(ExperimentCardFooter)
+    gtag.trackExperimentPageClick('ExperimentCardFooter')
     push({
       pathname: `/experiments/${accessionCode}/${formatURLString(title)}`,
       query: { ref: 'view-samples' }

--- a/src/components/ExperimentCardHeader.js
+++ b/src/components/ExperimentCardHeader.js
@@ -11,7 +11,7 @@ export const ExperimentCardHeader = ({ experiment, isLinked = false }) => {
   const { setResponsive } = useResponsive()
 
   const handleClick = () => {
-    gtag.trackExperimentPageClick(ExperimentCardHeader)
+    gtag.trackExperimentPageClick('ExperimentCardHeader')
   }
 
   return (

--- a/src/components/MoveToDatasetButton.js
+++ b/src/components/MoveToDatasetButton.js
@@ -57,7 +57,7 @@ export const MoveToDatasetButton = ({ dataset }) => {
 
   const handleSubmit = async () => {
     await handlers[action]()
-    gtag.trackDatasetAction(MoveToDatasetModal)
+    gtag.trackDatasetAction('MoveToDatasetModal')
     handleReset()
   }
 

--- a/src/components/RemoveAllButton.js
+++ b/src/components/RemoveAllButton.js
@@ -16,7 +16,7 @@ export const RemoveAllButton = () => {
   const handleRemoveAll = () => {
     clearDataset()
     closeModal(id)
-    gtag.trackDatasetAction(RemoveAllButton)
+    gtag.trackDatasetAction('RemoveAllButton')
   }
 
   return (

--- a/src/components/RemoveDatasetButton.js
+++ b/src/components/RemoveDatasetButton.js
@@ -11,7 +11,7 @@ export const RemoveDatasetButton = ({ dataToRemove }) => {
 
   const handleClick = () => {
     removeSamples(dataToRemove)
-    gtag.trackDatasetAction(RemoveDatasetButton)
+    gtag.trackDatasetAction('RemoveDatasetButton')
   }
 
   return (

--- a/src/components/SignUpBlock.js
+++ b/src/components/SignUpBlock.js
@@ -31,7 +31,7 @@ export const SignUpBlock = () => {
               setSubmitted(false)
             } else {
               setSubmitted(true)
-              gtag.trackEmailSubscription(SignUpBlock)
+              gtag.trackEmailSubscription('SignUpBlock')
             }
 
             setSubmitting(false)


### PR DESCRIPTION
## Issue Number

N/A

## Purpose/Implementation Notes

We attempted to prevent component name minification using `TerserPlugin` in #564, but Vercel still minifies them during deployment. As a workaround, we've updated our implementation to pass component names as strings to `gtag` custom events instead of passing the `Component` object.

This approach is simpler and more reliable for accurate GA4 data tracking.

## Types of changes

- Bugfix (non-breaking change which fixes an issue)

## Functional tests

The implementation was tested in the `dev` Analytics account — `Refine.bio Web - Dev`.

## Checklist

<!-- Put an `x` in the boxes that apply. -->

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added necessary documentation (if appropriate)
- [ ] Any dependent changes have been merged and published in downstream modules

## Screenshots

N/A
